### PR TITLE
cleanup: diagnostic code constants + shared list_contains_str helper

### DIFF
--- a/src/cli.bl
+++ b/src/cli.bl
@@ -46,6 +46,7 @@ import query.{query_filtered_layer}
 import diagnostics.{
     Diag, diag_count, diag_warn_count, diag_ice_count, diag_flush, diag_reset,
     diag_source_file, diag_error_no_loc, diag_format, diag_explain,
+    MISSING_NATIVE_DEP, NATIVE_DEP_UNAVAILABLE_CROSS,
 }
 import daemon.{Daemon, daemon_start}
 import docgen.{generate_doc}
@@ -804,7 +805,7 @@ fn validate_ffi_native_deps(ffi_libs: List[Str]) -> Int ! Diag.Report {
     while i < ffi_libs.len() {
         let lib = ffi_libs.get(i).unwrap()
         if manifest_has_native_dep(lib) == 0 {
-            diag_error_no_loc("MissingNativeDep", "E0820", "@ffi references undeclared native dependency \"{lib}\"", "add to blink.toml:\n  [native-dependencies]\n  {lib} = \{ system = true \}")
+            diag_error_no_loc("MissingNativeDep", MISSING_NATIVE_DEP, "@ffi references undeclared native dependency \"{lib}\"", "add to blink.toml:\n  [native-dependencies]\n  {lib} = \{ system = true \}")
             errors = errors + 1
         }
         i = i + 1
@@ -825,7 +826,7 @@ fn validate_cross_target_deps(target: Str) -> Int ! Diag.Report {
         let dep_type = manifest_native_dep_type(name)
         let dep_link = manifest_native_dep_link(name)
         if dep_type == "system" && dep_link != "dynamic" {
-            diag_error_no_loc("NativeDepUnavailableCrossTarget", "E0821", "native dependency \"{name}\" is system-only but target is {target}", "cross-compilation requires vendored source or static archive\n  provide source: {name} = \{ path = \"vendor/{name}.c\" \}\n  or override linking: {name} = \{ system = true, link = \"dynamic\" \}")
+            diag_error_no_loc("NativeDepUnavailableCrossTarget", NATIVE_DEP_UNAVAILABLE_CROSS, "native dependency \"{name}\" is system-only but target is {target}", "cross-compilation requires vendored source or static archive\n  provide source: {name} = \{ path = \"vendor/{name}.c\" \}\n  or override linking: {name} = \{ system = true, link = \"dynamic\" \}")
             errors = errors + 1
         }
         i = i + 1

--- a/src/codegen_closures.bl
+++ b/src/codegen_closures.bl
@@ -16,7 +16,7 @@ import codegen_types.{
     scope_vars, push_scope, pop_scope, set_var, set_var_closure, set_var_struct, get_var_tp,
     fn_regs, fn_regs_idx, var_enums, mut_captured_vars,
     closure_captures, closure_cap_infos, closure_lit_nodes, closure_lit_cap_idxs, closure_param_names,
-    is_emitted_fn, is_enum_type, is_struct_type, is_mut_captured, resolve_variant,
+    is_emitted_fn, is_enum_type, is_struct_type, list_contains_str, resolve_variant,
     reg_fn_struct_ret, reg_fn_ret_from_ann,
     resolve_ret_type_from_ann, resolve_option_inner_from_ann, build_closure_sig_from_type_ann,
     cg_closure_counter, cg_closure_defs, cg_closure_promoter_defs, cg_closure_param_type_hint,
@@ -45,17 +45,6 @@ fn collect_pat_names(node: Int, target: List[Str]) {
 
 // ── Capture analysis ────────────────────────────────────────────────
 // Walk a closure body AST collecting free variable references.
-
-fn list_contains_str(lst: List[Str], val: Str) -> Int {
-    let mut i = 0
-    while i < lst.len() {
-        if lst.get(i).unwrap() == val {
-            return 1
-        }
-        i = i + 1
-    }
-    0
-}
 
 fn is_in_scope(name: Str) -> Int {
     let mut i = 0
@@ -718,7 +707,7 @@ pub fn prescan_mut_captures(block: Int) {
         while j < prescan_closure_idents.len() {
             let cident = prescan_closure_idents.get(j).unwrap()
             if mname == cident {
-                if is_mut_captured(mname) == 0 {
+                if list_contains_str(mut_captured_vars, mname) == 0 {
                     mut_captured_vars.push(mname)
                 }
             }
@@ -745,7 +734,7 @@ pub fn emit_closure(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, 
     while cap_i < captures.len() {
         let cap_name = captures.get(cap_i).unwrap()
         let cap_tp = get_var_tp(cap_name)
-        let cap_mut = if is_mut_captured(cap_name) != 0 { 1 } else { 0 }
+        let cap_mut = if list_contains_str(mut_captured_vars, cap_name) != 0 { 1 } else { 0 }
         closure_captures.push(CaptureEntry { name: cap_name, is_mut: cap_mut, tp_id: cap_tp })
         cap_i = cap_i + 1
     }

--- a/src/codegen_expr.bl
+++ b/src/codegen_expr.bl
@@ -42,8 +42,9 @@ import codegen_types.{
     get_variant_field_type_str, get_variant_index, get_variant_tag,
     infer_fn_type_args_from_types, is_compound_ct, is_compound_tag, is_data_enum,
     is_emitted_let, is_enum_type, is_fn_registered, is_generic_fn,
-    is_mut_captured, is_struct_type, is_trait_type,
-    list_iter_c_type, lookup_mono_base, mangle_generic_name,
+    is_struct_type, is_trait_type,
+    list_contains_str, list_iter_c_type, lookup_mono_base, mangle_generic_name,
+    mut_captured_vars,
     option_c_type, pop_scope, push_scope,
     reg_fn, reg_fn_ret_from_ann, reg_fn_ret_struct_inner,
     reg_fn_ret_type, reg_fn_struct_ret,
@@ -65,7 +66,13 @@ import codegen_types.{
 import codegen_derive.{ct_to_descriptor, descriptor_mangle, queue_promote_type}
 import codegen_methods.{emit_method_call, resolve_push_struct}
 import codegen_closures.{analyze_captures, emit_closure}
-import diagnostics.{diag_error, diag_error_at, diag_warn_at, diag_set_last_fix, diag_source_file}
+import diagnostics.{
+    diag_error, diag_error_at, diag_warn_at, diag_set_last_fix, diag_source_file,
+    COALESCE_REQUIRES_OPT, QM_INVALID_OPERAND, UNDEFINED_FUNCTION,
+    QM_RESULT_IN_NON_RESULT, QM_OPTION_IN_NON_OPTION,
+    MISSING_KEYWORD_ARG, INVALID_KEYWORD_ARG,
+    CLOSEABLE_ESCAPES_SCOPE, FILE_NOT_FOUND, RAW_BYPASSES_PARAM,
+}
 import std.path.{path_dirname}
 
 // codegen_expr.bl — Expression codegen, closures, capture analysis
@@ -265,7 +272,7 @@ pub fn emit_expr(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Dia
             expr_result_type = tp_get_kind(cap_entry.tp_id)
             return
         }
-        if is_mut_captured(name) != 0 {
+        if list_contains_str(mut_captured_vars, name) != 0 {
             let mut is_closure_param = 0
             let mut cpi = 0
             while cpi < closure_param_names.len() {
@@ -633,7 +640,7 @@ pub fn emit_expr(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Dia
             embed_path
         }
         if file_exists(full_path) != 1 {
-            diag_error("FileNotFound", "E1108", "#embed file not found: {full_path}", node_line(node), node_col(node), "")
+            diag_error("FileNotFound", FILE_NOT_FOUND, "#embed file not found: {full_path}", node_line(node), node_col(node), "")
             expr_result_str = "\"\""
             expr_result_type = CT_STRING
             return
@@ -971,10 +978,10 @@ pub fn emit_async_spawn_closure(closure_node: Int, wrapper_idx: Int, wrapper_nam
     while cap_i < captures.len() {
         let cap_name = captures.get(cap_i).unwrap()
         if is_emitted_let(cap_name) != 0 {
-            diag_error_at("CloseableEscapesScope", "E0601", "scoped binding '{cap_name}' from with...as block cannot be captured by async.spawn", closure_node, "remove the capture or move the work inside the with block")
+            diag_error_at("CloseableEscapesScope", CLOSEABLE_ESCAPES_SCOPE, "scoped binding '{cap_name}' from with...as block cannot be captured by async.spawn", closure_node, "remove the capture or move the work inside the with block")
         }
         let cap_tp = get_var_tp(cap_name)
-        let cap_mut = if is_mut_captured(cap_name) != 0 { 1 } else { 0 }
+        let cap_mut = if list_contains_str(mut_captured_vars, cap_name) != 0 { 1 } else { 0 }
         closure_captures.push(CaptureEntry { name: cap_name, is_mut: cap_mut, tp_id: cap_tp })
         cap_i = cap_i + 1
     }
@@ -1266,7 +1273,7 @@ fn emit_binop(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag.R
         let opt_inner = expr_option_inner
         let opt_inner_s = expr_option_inner_struct
         if left_type == CT_BOOL || left_type == CT_FLOAT || left_type == CT_STRING || left_type == CT_LIST || left_type == CT_RESULT || left_type == CT_CLOSURE {
-            diag_error_at("CoalesceRequiresOption", "E0502", "the ?? operator requires an Option value but got a non-Option type in function '{cg_current_fn_name}'", node, "")
+            diag_error_at("CoalesceRequiresOption", COALESCE_REQUIRES_OPT, "the ?? operator requires an Option value but got a non-Option type in function '{cg_current_fn_name}'", node, "")
         }
         emit_expr(node_right(node))
         let right_str = expr_result_str
@@ -1499,7 +1506,7 @@ fn emit_unaryop(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag
         let tmp = fresh_temp("__res")
         if operand_type == CT_RESULT {
             if cg_current_fn_ret != CT_RESULT {
-                diag_error_at("QuestionMarkResultInNonResult", "E0508", "'?' on Result in function '{cg_current_fn_name}' which does not return Result", node, "change the return type to Result")
+                diag_error_at("QuestionMarkResultInNonResult", QM_RESULT_IN_NON_RESULT, "'?' on Result in function '{cg_current_fn_name}' which does not return Result", node, "change the return type to Result")
                 diag_set_last_fix("replace", "-> Result[T, E]")
                 expr_result_str = "0"
                 expr_result_type = CT_INT
@@ -1558,7 +1565,7 @@ fn emit_unaryop(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag
             }
         } else if operand_type == CT_OPTION {
             if cg_current_fn_ret != CT_OPTION {
-                diag_error_at("QuestionMarkOptionInNonOption", "E0509", "'?' on Option in function '{cg_current_fn_name}' which does not return Option", node, "change the return type to Option")
+                diag_error_at("QuestionMarkOptionInNonOption", QM_OPTION_IN_NON_OPTION, "'?' on Option in function '{cg_current_fn_name}' which does not return Option", node, "change the return type to Option")
                 diag_set_last_fix("replace", "-> Option[T]")
                 expr_result_str = "0"
                 expr_result_type = CT_INT
@@ -1617,7 +1624,7 @@ fn emit_unaryop(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag
                 expr_option_inner_struct = ""
             }
         } else {
-            diag_error_at("QuestionMarkInvalidOperand", "E0502", "'?' requires a Result or Option value", node, "")
+            diag_error_at("QuestionMarkInvalidOperand", QM_INVALID_OPERAND, "'?' requires a Result or Option value", node, "")
             expr_result_str = "0"
             expr_result_type = CT_INT
         }
@@ -1676,11 +1683,11 @@ fn reorder_named_args(fn_name: Str, args_sl: Int, call_node: Int) ! Diag.Report 
                 k = k + 1
             }
             if valid == 0 {
-                diag_error_at("InvalidKeywordArg", "E0511", "no parameter named '{label}' in function '{fn_name}'", call_node, "check the function signature")
+                diag_error_at("InvalidKeywordArg", INVALID_KEYWORD_ARG, "no parameter named '{label}' in function '{fn_name}'", call_node, "check the function signature")
                 return
             }
         } else {
-            diag_error_at("InvalidKeywordArg", "E0511", "positional argument after named argument in call to '{fn_name}'", call_node, "place all positional arguments before named arguments")
+            diag_error_at("InvalidKeywordArg", INVALID_KEYWORD_ARG, "positional argument after named argument in call to '{fn_name}'", call_node, "place all positional arguments before named arguments")
             return
         }
         i = i + 1
@@ -1710,7 +1717,7 @@ fn reorder_named_args(fn_name: Str, args_sl: Int, call_node: Int) ! Diag.Report 
             j = j + 1
         }
         if found == 0 {
-            diag_error_at("MissingKeywordArg", "E0510", "missing keyword argument '{param_name}' in call to '{fn_name}'", call_node, "add '{param_name}: <value>'")
+            diag_error_at("MissingKeywordArg", MISSING_KEYWORD_ARG, "missing keyword argument '{param_name}' in call to '{fn_name}'", call_node, "add '{param_name}: <value>'")
             return
         }
         i = i + 1
@@ -2300,7 +2307,7 @@ fn emit_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag.Re
                 } else {
                     cls_expr = "((blink_closure*)blink_closure_get_capture(__self, {cap_idx_cls}))"
                 }
-            } else if is_mut_captured(fn_name) != 0 {
+            } else if list_contains_str(mut_captured_vars, fn_name) != 0 {
                 let mut is_closure_param_cc = 0
                 let mut cpi_cc = 0
                 while cpi_cc < closure_param_names.len() {
@@ -2487,7 +2494,7 @@ fn emit_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, Diag.Re
             }
         }
         if is_fn_registered(fn_name) == 0 && is_generic_fn(fn_name) == 0 {
-            diag_error_at("UndefinedFunction", "E0504", "undefined function '{fn_name}' called in '{cg_current_fn_name}'", node, "")
+            diag_error_at("UndefinedFunction", UNDEFINED_FUNCTION, "undefined function '{fn_name}' called in '{cg_current_fn_name}'", node, "")
             emit_line("/* undefined: {fn_name} */")
             expr_result_str = "0"
             expr_result_type = CT_INT
@@ -2906,7 +2913,7 @@ pub fn emit_template_construction(node: Int) ! Codegen.Emit, Codegen.Register, C
         if pk == NodeKind.Ident && node_str_val(part) == node_name(part) {
             current_literal = current_literal.concat(escape_c_string(node_str_val(part)))
         } else if is_raw_call(part) != 0 {
-            diag_warn_at("RawBypassesParam", "W0310", "Raw() bypasses query parameterization", part, "add @allow(RawBypassesParam) to suppress")
+            diag_warn_at("RawBypassesParam", RAW_BYPASSES_PARAM, "Raw() bypasses query parameterization", part, "add @allow(RawBypassesParam) to suppress")
             let inner = sublist_get(node_args(part), 0)
             emit_expr(inner)
             let raw_str = expr_result_str

--- a/src/codegen_methods.bl
+++ b/src/codegen_methods.bl
@@ -49,7 +49,12 @@ import codegen_types.{
     type_from_name, type_from_name_tag, type_name_from_ct, is_compound_tag, is_intrinsic_method, ue_methods,
     var_enums, VarEnumEntry
 }
-import diagnostics.{diag_error_at, diag_source_file}
+import diagnostics.{
+    diag_error_at, diag_source_file,
+    TEMPLATE_MISMATCH, UNRESOLVED_METHOD,
+    FFI_OFFSET_ON_SINGLETON, FFI_OFFSET_UNKNOWN_STRIDE,
+    WITH_PTR_BODY_TOO_COMPLEX,
+}
 
 // Arg offset for trait-qualified builtin calls: MapOps.contains_key(m, k) has receiver at args[0]
 let mut btc_arg_offset: Int = 0
@@ -1599,7 +1604,7 @@ pub fn emit_method_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Sco
                         if arg_kind == NodeKind.InterpString {
                             emit_template_construction(arg_node)
                         } else {
-                            diag_error_at("TemplateMismatch", "E0310", "expected Template, found Str — pass a string literal directly", arg_node, "use an interpolated string literal at the call site")
+                            diag_error_at("TemplateMismatch", TEMPLATE_MISMATCH, "expected Template, found Str — pass a string literal directly", arg_node, "use an interpolated string literal at the call site")
                             emit_expr(arg_node)
                         }
                     } else {
@@ -2071,7 +2076,7 @@ pub fn emit_method_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Sco
                     }
                 }
                 if handled == 0 {
-                    diag_error_at("WithPtrBodyTooComplex", "E0816", "Bytes.with_ptr body must be a single expression — extract complex logic into a helper that takes Ptr[U8]", cls_node, "use a single expression in the closure body")
+                    diag_error_at("WithPtrBodyTooComplex", WITH_PTR_BODY_TOO_COMPLEX, "Bytes.with_ptr body must be a single expression — extract complex logic into a helper that takes Ptr[U8]", cls_node, "use a single expression in the closure body")
                     expr_result_str = "0"
                     expr_result_type = CT_VOID
                 }
@@ -2879,7 +2884,7 @@ pub fn emit_method_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Sco
             if node_kind(obj_node) == NodeKind.Ident {
                 let recv_name = node_name(obj_node)
                 if is_ffi_ptr_array_var(recv_name) == 0 && get_var_ffi_ptr_struct(recv_name) != "" {
-                    diag_error_at("FfiOffsetOnSingleton", "E0813", "Ptr.offset() called on Ptr from scope.alloc[T]() — use scope.alloc_n[T](n) for arrays", node, "use scope.alloc_n[T](n) instead of scope.alloc[T]()")
+                    diag_error_at("FfiOffsetOnSingleton", FFI_OFFSET_ON_SINGLETON, "Ptr.offset() called on Ptr from scope.alloc[T]() — use scope.alloc_n[T](n) for arrays", node, "use scope.alloc_n[T](n) instead of scope.alloc[T]()")
                 }
                 struct_name = get_var_ffi_ptr_struct(recv_name)
             } else {
@@ -2887,7 +2892,7 @@ pub fn emit_method_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Sco
                 struct_name = ffi_offset_pending_struct
             }
             if struct_name == "" {
-                diag_error_at("FfiOffsetUnknownStride", "E0813", "Ptr.offset() requires a Ptr to an @ffi.struct typedef so the stride is known", node, "use a Ptr[T] where T is annotated @ffi.struct")
+                diag_error_at("FfiOffsetUnknownStride", FFI_OFFSET_UNKNOWN_STRIDE, "Ptr.offset() requires a Ptr to an @ffi.struct typedef so the stride is known", node, "use a Ptr[T] where T is annotated @ffi.struct")
             }
             let inner_c = if struct_name != "" { c_type_c_name(struct_name) } else { "char" }
             let args_sl = node_args(node)
@@ -3223,7 +3228,7 @@ pub fn emit_method_call(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Sco
 
     // Generic fallback — emit diagnostic and produce safe placeholder
     let recv_type_name = type_name_from_ct(obj_type)
-    diag_error_at("UnresolvedMethod", "E0505", "unresolved method '.{method}' on type {recv_type_name} in '{cg_current_fn_name}'", node, "")
+    diag_error_at("UnresolvedMethod", UNRESOLVED_METHOD, "unresolved method '.{method}' on type {recv_type_name} in '{cg_current_fn_name}'", node, "")
     expr_result_str = "(void)0"
     expr_result_type = CT_VOID
 }

--- a/src/codegen_stmt.bl
+++ b/src/codegen_stmt.bl
@@ -40,7 +40,7 @@ import codegen_types.{
     get_variant_field_type_str, get_variant_index, get_variant_tag,
     impl_method_self_name, builtin_receiver_type_name,
     is_compound_ct, is_data_enum, is_enum_type,
-    is_intrinsic_method, is_mut_captured, is_named_type, is_runtime_header_fn, is_struct_type, is_trait_type, list_iter_c_type,
+    is_intrinsic_method, is_named_type, is_runtime_header_fn, is_struct_type, is_trait_type, list_contains_str, list_iter_c_type,
     lookup_assoc_type, lookup_impl_type_for_trait, mangle_generic_name, mangle_impl_method, match_scrut_enum,
     match_scruts, mono_fns, mono_instances, mut_captured_vars, option_c_type,
     option_c_type_mixed, pop_scope, ptr_inner_c_type, push_scope,
@@ -77,7 +77,11 @@ import codegen_expr.{
     expr_result_type
 }
 import codegen_derive.{ct_to_descriptor, desc_primary_ct, descriptor_c_type, descriptor_mangle, emit_promote_elem_into, inner_desc_of, queue_promote_type}
-import diagnostics.{Diag, diag_error_at, diag_warn_at, diag_file_for_node}
+import diagnostics.{
+    Diag, diag_error_at, diag_warn_at, diag_file_for_node,
+    ARENA_CLOSURE_TAIL_NONLITERAL, ARENA_CLOSURE_UNSUPPORTED_CAP,
+    MISSING_CANONICAL_HEADER,
+}
 import pkg.manifest.{manifest_header_is_declared, manifest_name}
 import compiler.{trace}
 
@@ -2049,7 +2053,7 @@ fn emit_let_binding(node: Int) ! Codegen.Emit, Codegen.Register, Codegen.Scope, 
     if name.starts_with("_") {
         emit_line("(void){cname};")
     }
-    if is_mut_captured(name) != 0 {
+    if list_contains_str(mut_captured_vars, name) != 0 {
         let cell_type = c_type_str(val_type)
         emit_line("{cell_type}* {cname}_cell = ({cell_type}*)blink_alloc(sizeof({cell_type}));")
         emit_line("*{cname}_cell = {cname};")
@@ -2623,7 +2627,7 @@ fn emit_closure_tail_promotion(
         let e = closure_captures.get(info.start + ci).unwrap()
         if descriptor_from_capture(e) == "" {
             diag_error_at(
-                "ArenaClosureUnsupportedCapture", "E0702d",
+                "ArenaClosureUnsupportedCapture", ARENA_CLOSURE_UNSUPPORTED_CAP,
                 "cannot promote closure tail of 'with arena \{ expr }': capture of unsupported kind",
                 tail_node,
                 "construct the closure outside the 'with arena \{ }' block"
@@ -2658,16 +2662,7 @@ fn emit_closure_tail_promotion(
         let desc = descriptor_from_capture(e)
         queue_promote_type(desc)
         emit_trace_arena_capture("tail", i, desc, tail_node)
-        let mut declared_in_block = 0
-        if e.is_mut != 0 {
-            let mut bi = 0
-            while bi < block_local_muts.len() {
-                if block_local_muts.get(bi).unwrap() == e.name {
-                    declared_in_block = 1
-                }
-                bi = bi + 1
-            }
-        }
+        let declared_in_block = if e.is_mut != 0 { list_contains_str(block_local_muts, e.name) } else { 0 }
         emit_promote_capture_slot("{src_tmp}->captures[{i}]", "{p_caps}[{i}]", desc, e.is_mut, declared_in_block, e.tp_id)
         i = i + 1
     }
@@ -2791,7 +2786,7 @@ fn emit_block_then_capture(block: Int, result_sink: Str, arena_prev: Str) -> Str
         let cap_idx = if lit_node == -1 { -1 } else { lookup_closure_lit_cap_idx(lit_node) }
         if cap_idx == -1 {
             diag_error_at(
-                "ArenaClosureTailNonLiteral", "E0702a",
+                "ArenaClosureTailNonLiteral", ARENA_CLOSURE_TAIL_NONLITERAL,
                 "cannot promote closure tail of 'with arena \{ expr }' whose origin is not a closure literal bound in this block",
                 tail_node,
                 "construct the closure outside the 'with arena \{ }' block, or bind it via `let <name> = fn(…) \{ … }` immediately inside this block"
@@ -4548,7 +4543,7 @@ pub fn emit_struct_typedef(td_node: Int) ! Codegen.Emit, Diag.Report {
             if manifest_name != "" && manifest_header_is_declared(header) == 0 {
                 diag_warn_at(
                     "MissingCanonicalHeader",
-                    "W0812",
+                    MISSING_CANONICAL_HEADER,
                     "@ffi.struct '{name}' declares header '{header}' but no [native-dependencies] entry in blink.toml lists it",
                     td_node,
                     "add the header to blink.toml: [native-dependencies] <dep>.headers = [\"{header}\"]"

--- a/src/codegen_types.bl
+++ b/src/codegen_types.bl
@@ -3,7 +3,10 @@ import parser.{
     node_trait_name, node_type_ann, node_type_name, node_type_params,
     sublist_get, sublist_length
 }
-import diagnostics.{Diag, diag_error_no_loc, diag_set_last_fix}
+import diagnostics.{
+    Diag, diag_error_no_loc, diag_set_last_fix,
+    UNDECLARED_EFFECT, INSUFFICIENT_CAPABILITY,
+}
 
 effect Codegen {
     effect Emit
@@ -1612,10 +1615,10 @@ fn set_var_full(name: Str, ctype: Int, is_mut: Int, inner1: Int, inner2: Int, sn
     scope_vars.push(ScopeVar { name: name, ctype: ctype, is_mut: is_mut, inner1: inner1, inner2: inner2, sname: sname, sname2: sname2, extra: extra, tp_id: sv_tp(ctype, inner1, inner2, sname) })
 }
 
-pub fn is_mut_captured(name: Str) -> Int {
+pub fn list_contains_str(lst: List[Str], val: Str) -> Int {
     let mut i = 0
-    while i < mut_captured_vars.len() {
-        if mut_captured_vars.get(i).unwrap() == name {
+    while i < lst.len() {
+        if lst.get(i).unwrap() == val {
             return 1
         }
         i = i + 1
@@ -2226,7 +2229,7 @@ pub fn check_effect_propagation(callee_name: Str) ! Diag.Report {
             }
         }
         if satisfied == 0 {
-            diag_error_no_loc("UndeclaredEffect", "E0500", "function '{callee_name}' requires effect '{callee_eff}' but caller '{cg_current_fn_name}' does not declare it", "add '! {callee_eff}' to the function signature of '{cg_current_fn_name}'")
+            diag_error_no_loc("UndeclaredEffect", UNDECLARED_EFFECT, "function '{callee_name}' requires effect '{callee_eff}' but caller '{cg_current_fn_name}' does not declare it", "add '! {callee_eff}' to the function signature of '{cg_current_fn_name}'")
             diag_set_last_fix("insert", "! {callee_eff}")
         }
         ci = ci + 1
@@ -2258,7 +2261,7 @@ pub fn check_capabilities_budget(fn_name: Str, effects_sl: Int) ! Diag.Report {
             bi = bi + 1
         }
         if allowed == 0 {
-            diag_error_no_loc("InsufficientCapability", "E0501", "function '{fn_name}' uses effect '{eff_name}' which is not in @capabilities budget", "add the effect to @capabilities")
+            diag_error_no_loc("InsufficientCapability", INSUFFICIENT_CAPABILITY, "function '{fn_name}' uses effect '{eff_name}' which is not in @capabilities budget", "add the effect to @capabilities")
             diag_set_last_fix("insert", "{eff_name}")
         }
         ei = ei + 1

--- a/src/compiler.bl
+++ b/src/compiler.bl
@@ -2,7 +2,13 @@ import ast.{NodeKind}
 import lexer.{Lex, lex}
 import parser.{Parse, parser_reset, parse_program, new_node, new_sublist, sublist_push, finalize_sublist, sublist_get, sublist_length, pos, node_count, node_kind, node_name, node_args, node_elements, node_handlers, node_params, node_fields, node_stmts, node_arms, node_methods, node_module, node_captures, node_str_val, node_is_pub, node_set_module, node_set_is_pub, node_set_name, node_set_handlers, node_set_params, node_set_fields, node_set_stmts, node_set_arms, node_set_methods, node_set_args, node_set_captures}
 import typecheck.{tc_import_modules, tc_import_nodes, tc_reexport_source, tc_reexport_modules, tc_is_module_used}
-import diagnostics.{Diag, diag_register_file_range, lint_set_override, diag_normalize_path, diag_set_last_fix, diag_error_no_loc, diag_warn_at, diag_reset, diag_source_file, diag_module_files}
+import diagnostics.{
+    Diag, diag_register_file_range, lint_set_override, diag_normalize_path,
+    diag_set_last_fix, diag_error_no_loc, diag_warn_at, diag_reset,
+    diag_source_file, diag_module_files,
+    CIRCULAR_DEPENDENCY, VERSION_CONFLICT, INVALID_MODULE_ANNOTATION,
+    PACKAGE_ENTRY_NOT_FOUND, ORPHAN_FILE, MODULE_NOT_FOUND, UNUSED_IMPORT,
+}
 import pkg.lockfile.{lockfile_load, lockfile_find_pkg, lockfile_pkg_count, lock_pkg_sources, lock_pkg_names, lock_pkg_versions}
 import pkg.manifest.{manifest_clear, manifest_load, manifest_has_dep, manifest_name, lint_names, lint_levels}
 import std.path.{path_join, path_dirname, path_parent, path_basename, path_stem}
@@ -85,7 +91,7 @@ pub fn compile_to_program(file_path: Str, use_prelude: Int) -> Int ! Lex.Tokeniz
 
     let cycle_path = detect_package_cycles()
     if cycle_path != "" {
-        diag_error_no_loc("CircularDependency", "E1002", "circular package dependency: {cycle_path}", "extract shared types into a common package")
+        diag_error_no_loc("CircularDependency", CIRCULAR_DEPENDENCY, "circular package dependency: {cycle_path}", "extract shared types into a common package")
     }
 
     let mut final_program = program
@@ -259,7 +265,7 @@ fn validate_lockfile_versions() ! Diag.Report {
             if lock_pkg_names.get(j).unwrap() == name {
                 let other_version = lock_pkg_versions.get(j).unwrap()
                 if other_version != version {
-                    diag_error_no_loc("VersionConflict", "E1004", "dependency version conflict for '{name}': version {version} and version {other_version} both required — only one version per package is allowed", "run 'blink update' to resolve, or pin dependencies to compatible versions")
+                    diag_error_no_loc("VersionConflict", VERSION_CONFLICT, "dependency version conflict for '{name}': version {version} and version {other_version} both required — only one version per package is allowed", "run 'blink update' to resolve, or pin dependencies to compatible versions")
                     return
                 }
             }
@@ -477,7 +483,7 @@ fn resolve_from_lockfile(dotted_path: Str, _src_root: Str) -> Option[Str] ! Diag
         if file_exists(entry_path) == 1 {
             return Some(entry_path)
         }
-        diag_error_no_loc("PackageEntryNotFound", "E1009", "package entry not found: '{dotted_path}' — expected '{entry_path}'", "create '{entry_path}', or check the 'name' field in '{manifest_path}'")
+        diag_error_no_loc("PackageEntryNotFound", PACKAGE_ENTRY_NOT_FOUND, "package entry not found: '{dotted_path}' — expected '{entry_path}'", "create '{entry_path}', or check the 'name' field in '{manifest_path}'")
         return Some("")
     }
 
@@ -502,7 +508,7 @@ pub fn resolve_module_path(dotted_path: Str, src_root: Str) -> Str ! Diag.Report
     // only stdlib (std.*) and bundled package-manager modules (pkg.*) are
     // allowed without a package context.
     if src_root == "" && !is_std_ns && !is_pkg_ns {
-        diag_error_no_loc("OrphanFile", "E1010", "import '{dotted_path}' is not allowed — file has no enclosing blink.toml so it is not part of any package", "create a blink.toml above this file, or import only std.* / pkg.* modules")
+        diag_error_no_loc("OrphanFile", ORPHAN_FILE, "import '{dotted_path}' is not allowed — file has no enclosing blink.toml so it is not part of any package", "create a blink.toml above this file, or import only std.* / pkg.* modules")
         return ""
     }
 
@@ -607,9 +613,9 @@ pub fn resolve_module_path(dotted_path: Str, src_root: Str) -> Str ! Diag.Report
 
     let npkgs = lockfile_pkg_count()
     if npkgs > 0 {
-        diag_error_no_loc("ModuleNotFound", "E1200", "module not found: {dotted_path} (looked at: {full_bl}, checked {npkgs} lockfile packages)", "")
+        diag_error_no_loc("ModuleNotFound", MODULE_NOT_FOUND, "module not found: {dotted_path} (looked at: {full_bl}, checked {npkgs} lockfile packages)", "")
     } else {
-        diag_error_no_loc("ModuleNotFound", "E1200", "module not found: {dotted_path} (looked at: {full_bl}; no dependencies - run `blink add` to add packages)", "")
+        diag_error_no_loc("ModuleNotFound", MODULE_NOT_FOUND, "module not found: {dotted_path} (looked at: {full_bl}; no dependencies - run `blink add` to add packages)", "")
     }
     ""
 }
@@ -1055,7 +1061,7 @@ fn load_module(dotted_path: Str, file_path: Str, src_root: Str, all_programs: Li
             if pkg != "" && pkg != "__root__" && ann_val != pkg {
                 let saved_diag = diag_source_file
                 diag_source_file = display_path
-                diag_error_no_loc("InvalidModuleAnnotation", "E1008", "@module(\"{ann_val}\") is invalid — file is in package '{pkg}', @module can only use the parent package name '{pkg}'", "use @module(\"{pkg}\") or remove the annotation")
+                diag_error_no_loc("InvalidModuleAnnotation", INVALID_MODULE_ANNOTATION, "@module(\"{ann_val}\") is invalid — file is in package '{pkg}', @module can only use the parent package name '{pkg}'", "use @module(\"{pkg}\") or remove the annotation")
                 diag_source_file = saved_diag
             } else {
                 // Spec §10.5: the package entry file is <root>/src/<name>.bl.
@@ -1072,7 +1078,7 @@ fn load_module(dotted_path: Str, file_path: Str, src_root: Str, all_programs: Li
                     if basename == entry_pkg && ann_val != entry_pkg {
                         let saved_diag = diag_source_file
                         diag_source_file = display_path
-                        diag_error_no_loc("InvalidModuleAnnotation", "E1008", "@module(\"{ann_val}\") is invalid — entry file of package '{entry_pkg}' must declare @module(\"{entry_pkg}\") or omit the annotation", "use @module(\"{entry_pkg}\") or remove the annotation")
+                        diag_error_no_loc("InvalidModuleAnnotation", INVALID_MODULE_ANNOTATION, "@module(\"{ann_val}\") is invalid — entry file of package '{entry_pkg}' must declare @module(\"{entry_pkg}\") or omit the annotation", "use @module(\"{entry_pkg}\") or remove the annotation")
                         diag_source_file = saved_diag
                     }
                 }
@@ -1259,7 +1265,7 @@ pub fn check_unused_imports() ! Diag.Report {
             let imp_node = root_import_nodes.get(ii).unwrap()
             if node_is_pub(imp_node) == 0 {
                 let display_name = if qualifier != "" { qualifier } else { mod_key }
-                diag_warn_at("UnusedImport", "W0602", "module '{display_name}' is imported but not used", imp_node, "remove the unused import")
+                diag_warn_at("UnusedImport", UNUSED_IMPORT, "module '{display_name}' is imported but not used", imp_node, "remove the unused import")
                 diag_set_last_fix("Remove unused import", "")
             }
         }

--- a/src/diagnostics.bl
+++ b/src/diagnostics.bl
@@ -9,6 +9,115 @@ effect Diag {
 // Collects errors/warnings into List[DiagEntry], then flushes as
 // JSON (one object per line) or human-readable format.
 
+// ── Diagnostic code constants ────────────────────────────────────────
+// One constant per (code, short-name) pair used at emit sites.
+// When a single code maps to multiple short-names (e.g. E0502 covers both
+// QM operand and ?? receiver), each pair gets its own constant.
+// When a single short-name covers multiple codes (e.g. TraitContract for
+// E0900-E0906), the constant is suffixed with the numeric tail.
+
+// E0300+ — type errors
+pub const TYPE_ERROR              = "E0300"
+pub const TEMPLATE_MISMATCH       = "E0310"
+
+// E0500+ — effects, capabilities, ?-propagation
+pub const UNDECLARED_EFFECT       = "E0500"
+pub const CAPABILITY_BUDGET       = "E0501"
+pub const INSUFFICIENT_CAPABILITY = "E0501"
+pub const QM_INVALID_OPERAND      = "E0502"
+pub const COALESCE_REQUIRES_OPT   = "E0502"
+pub const UNDEFINED_FUNCTION      = "E0504"
+pub const UNRESOLVED_METHOD       = "E0505"
+pub const UNDEFINED_VARIABLE      = "E0506"
+pub const UNKNOWN_TYPE            = "E0507"
+pub const QM_RESULT_IN_NON_RESULT = "E0508"
+pub const QM_OPTION_IN_NON_OPTION = "E0509"
+pub const MISSING_KEYWORD_ARG     = "E0510"
+pub const INVALID_KEYWORD_ARG     = "E0511"
+pub const QM_ERROR_MISMATCH       = "E0512"
+
+// E0600+ — closures, scoping
+pub const CLOSEABLE_ESCAPES_SCOPE = "E0601"
+
+// E0700+ — arena escape analysis
+pub const ARENA_VALUE_ESCAPES        = "E0700"
+pub const ARENA_TYPE_CONTAINS_CYCLE  = "E0701"
+// E0702 is the umbrella code covered by diag_explain;
+// emit sites use the more specific E0702a / E0702d sub-codes.
+pub const ARENA_CLOSURE_TAIL_UNSUPPORTED = "E0702"
+pub const ARENA_CLOSURE_TAIL_NONLITERAL = "E0702a"
+pub const ARENA_CLOSURE_UNSUPPORTED_CAP = "E0702d"
+
+// E0800+ — FFI
+pub const PUB_FFI                  = "E0801"
+pub const FFI_NO_EFFECTS           = "E0802"
+pub const CONTRACT_ON_FFI          = "E0803"
+pub const INVALID_PTR_TYPE         = "E0810"
+pub const PTR_OUTSIDE_FFI          = "E0811"
+pub const FFI_STRUCT_GC_FIELD      = "E0812"
+pub const FFI_OFFSET_ON_SINGLETON  = "E0813"
+pub const FFI_OFFSET_UNKNOWN_STRIDE = "E0813"
+pub const BYTES_GROW_IN_WITH_PTR   = "E0814"
+pub const PINNED_BYTES_ESCAPE      = "E0815"
+pub const WITH_PTR_BODY_TOO_COMPLEX = "E0816"
+pub const BYTES_PTR_CAST_FORBIDDEN = "E0817"
+pub const MISSING_NATIVE_DEP       = "E0820"
+pub const NATIVE_DEP_UNAVAILABLE_CROSS = "E0821"
+
+// E0900–E0906 — trait contract (one short-name spans 7 codes)
+pub const TRAIT_CONTRACT_900 = "E0900"
+pub const TRAIT_CONTRACT_901 = "E0901"
+pub const TRAIT_CONTRACT_902 = "E0902"
+pub const TRAIT_CONTRACT_903 = "E0903"
+pub const TRAIT_CONTRACT_904 = "E0904"
+pub const TRAIT_CONTRACT_905 = "E0905"
+pub const TRAIT_CONTRACT_906 = "E0906"
+
+// E1000+ — module / package resolution
+pub const CIRCULAR_DEPENDENCY      = "E1002"
+pub const PRIVATE_ITEM_ACCESS      = "E1003"
+pub const VERSION_CONFLICT         = "E1004"
+pub const AMBIGUOUS_IMPORT         = "E1005"
+pub const IMPORT_NOT_SELECTED      = "E1006"
+pub const MODULE_QUALIFIED_TYPE    = "E1007"
+pub const INVALID_MODULE_ANNOTATION = "E1008"
+pub const PACKAGE_ENTRY_NOT_FOUND  = "E1009"
+pub const ORPHAN_FILE              = "E1010"
+pub const INVALID_PACKAGE_NAME     = "E1011"
+pub const INLINE_MODULE_NOT_SUPPORTED = "E1015"
+pub const PACKAGE_NOT_DECLARED     = "E1052"
+
+// E1100+ — parser
+pub const UNEXPECTED_ANNOTATION   = "E1100"
+pub const UNEXPECTED_TOKEN        = "E1100"
+pub const UNEXPECTED_TOKEN_STRING = "E1101"
+pub const UNEXPECTED_TOKEN_PATTERN = "E1102"
+pub const KEYWORD_AS_IDENTIFIER   = "E1103"
+pub const EMPTY_BRACE_EXPR        = "E1107"
+pub const FILE_NOT_FOUND          = "E1108"
+pub const UNKNOWN_INTRINSIC       = "E1108"
+pub const MUT_FIELD_NOT_SUPPORTED = "E1109"
+
+// E1200 — module not found / string-backed enum
+pub const MODULE_NOT_FOUND          = "E1200"
+pub const INVALID_STRING_BACKED_ENUM = "E1200"
+
+// W0xxx — warnings
+pub const RAW_BYPASSES_PARAM      = "W0310"
+pub const UNKNOWN_METHOD          = "W0501"
+pub const INCOMPLETE_STATE_RESTORE = "W0550"
+pub const UNRESTORED_MUTATION     = "W0551"
+pub const UNUSED_VARIABLE         = "W0600"
+pub const SET_BUT_NOT_READ        = "W0601"
+pub const UNUSED_IMPORT           = "W0602"
+pub const SHADOWED_VARIABLE       = "W0603"
+pub const BITWISE_PRECEDENCE      = "W0700"
+pub const UNREACHABLE_CODE        = "W0700"
+pub const ARENA_EFFECT_REDUNDANT  = "W0701"
+pub const UNAUDITED_FFI           = "W0800"
+pub const MISSING_CANONICAL_HEADER = "W0812"
+pub const DEPRECATED_USAGE        = "W2000"
+
 // ── Diagnostic struct ────────────────────────────────────────────────
 
 pub type DiagEntry {
@@ -393,166 +502,166 @@ pub fn diag_reset() {
 // ── Error catalog ─────────────────────────────────────────────────
 
 pub fn diag_explain(code: Str) -> Str {
-    if code == "E0300" {
+    if code == TYPE_ERROR {
         return "E0300 -- TypeError\n\nA type mismatch was detected during type checking.\n\nCommon causes:\n  - Passing a value of the wrong type to a function\n  - Using '?' in a function that does not return Result\n  - Assigning a value to a variable of incompatible type\n\nFix: check the expected and actual types in the error message and\nadjust your code to match.\n\n  fn add(a: Int, b: Int) -> Int \{ a + b \}\n  add(1, \"two\")  // E0300: expected Int, got Str"
     }
-    if code == "E0500" {
+    if code == UNDECLARED_EFFECT {
         return "E0500 -- UndeclaredEffect\n\nA function calls another function that requires an effect, but the\ncaller does not declare that effect in its signature.\n\nFix: add '! EffectName' to the calling function's signature.\n\n  fn greet() ! IO \{\n      io.println(\"hello\")  // IO effect declared\n  \}\n\n  fn bad() \{\n      io.println(\"hello\")  // E0500: requires IO but bad() has none\n  \}"
     }
-    if code == "E0501" {
+    if code == INSUFFICIENT_CAPABILITY {
         return "E0501 -- InsufficientCapability\n\nA function uses an effect that is not listed in the module's\n@capabilities budget.\n\nFix: add the effect to the @capabilities annotation at the top of\nyour module.\n\n  @capabilities(IO, Net)\n  fn fetch() ! IO, Net \{ ... \}  // OK -- both in budget"
     }
-    if code == "E0502" {
+    if code == QM_INVALID_OPERAND {
         return "E0502 -- InvalidOperand for ? or ??\n\nThe '?' or '??' operator was used on a value that is not the\nexpected type. '?' requires Result or Option, '??' requires Option.\n\nCommon causes:\n  - Using '?' on a plain value instead of a Result or Option\n  - Using '??' on a Result instead of an Option\n\n  let val = some_option ?? \"default\"  // OK\n  let res = try_parse()?              // OK -- ? on Result\n  let inner = some_option?            // OK -- ? on Option (in Option-returning fn)"
     }
-    if code == "E0504" {
+    if code == UNDEFINED_FUNCTION {
         return "E0504 -- UndefinedFunction\n\nA function was called that has not been defined or imported.\n\nCommon causes:\n  - Typo in the function name\n  - Forgetting to import the module that defines the function\n  - The function is private (not pub) in another module\n\nFix: check the function name spelling, or add the appropriate import.\n\n  import math\n  let x = math.sqrt(4.0)  // OK -- imported"
     }
-    if code == "E0505" {
+    if code == UNRESOLVED_METHOD {
         return "E0505 -- UnresolvedMethod\n\nA method call could not be resolved for the receiver's type.\n\nCommon causes:\n  - Calling a method that does not exist on that type\n  - The variable's type is not what you expected\n  - Missing trait implementation\n\nFix: check the receiver type and available methods.\n\n  let x: Int = 42\n  x.contains(\"a\")  // E0505: Int has no .contains() method"
     }
-    if code == "E0506" {
+    if code == UNDEFINED_VARIABLE {
         return "E0506 -- UndefinedVariable\n\nA variable was referenced that has not been declared in scope.\n\nCommon causes:\n  - Typo in the variable name\n  - Using a variable before it is declared\n  - Variable is out of scope (declared in a different block)\n\n  let name = \"Blink\"\n  io.println(nane)  // E0506: 'nane' -- did you mean 'name'?"
     }
-    if code == "E0507" {
+    if code == UNKNOWN_TYPE {
         return "E0507 -- UnknownType\n\nA type name was used that the compiler does not recognize.\n\nCommon causes:\n  - Typo in the type name\n  - Forgetting to define or import the type\n  - Using a type from a module that is not imported\n\n  type Point \{ x: Int, y: Int \}\n  let p: Piont = ...  // E0507: unknown type 'Piont'"
     }
-    if code == "E0508" {
+    if code == QM_RESULT_IN_NON_RESULT {
         return "E0508 -- QuestionMarkResultInNonResult\n\nThe '?' operator was used on a Result value inside a function that\ndoes not return Result.\n\nFix: change the function's return type to Result[T, E].\n\n  fn parse(s: Str) -> Result[Int, Str] \{ ... \}\n\n  fn caller() -> Result[Int, Str] \{\n      let n = parse(\"42\")?  // OK -- caller returns Result\n      Ok(n)\n  \}"
     }
-    if code == "E0509" {
+    if code == QM_OPTION_IN_NON_OPTION {
         return "E0509 -- QuestionMarkOptionInNonOption\n\nThe '?' operator was used on an Option value inside a function that\ndoes not return Option.\n\nFix: change the function's return type to Option[T].\n\n  fn find(items: List[Str], key: Str) -> Option[Str] \{\n      items.get(0)?  // OK -- function returns Option\n  \}"
     }
-    if code == "E0512" {
+    if code == QM_ERROR_MISMATCH {
         return "E0512 -- QuestionMarkErrorMismatch\n\nThe '?' operator was used on a Result whose error type does not\nmatch the enclosing function's return error type.\n\nFix: ensure both error types are the same, or convert the error.\n\n  fn parse(s: Str) -> Result[Int, ParseError] \{ ... \}\n\n  fn caller() -> Result[Str, ParseError] \{\n      let n = parse(\"42\")?  // OK -- both use ParseError\n      Ok(n.to_string())\n  \}"
     }
-    if code == "E0700" {
+    if code == ARENA_VALUE_ESCAPES {
         return "E0700 -- ArenaValueEscapes\n\nA value allocated inside a 'with arena \{ }' block escapes the\narena's scope. Arena-allocated memory is freed when the arena exits,\nso references that survive the block would dangle.\n\nCommon causes:\n  - Storing an arena value into a long-lived field or global\n  - Capturing an arena value in a closure that outlives the block\n  - Passing an arena value to a function that keeps it\n\nThe diagnostic prints the resolved promotion target — either\n'promoted into: outer arena' (when the escaping site is inside a\nnested 'with arena') or 'promoted into: GC heap' (outermost block) —\nso nested-arena escapes are debuggable without guessing the shape of\nthe enclosing scope.\n\nFix: remove '! Arena' and let the value be GC-managed, or copy the\nvalue explicitly before it leaves the arena scope."
     }
-    if code == "E0702" {
+    if code == ARENA_CLOSURE_TAIL_UNSUPPORTED {
         return "E0702 -- ArenaClosureTailUnsupported\n\nThe tail expression of 'with arena \{ expr }' evaluates to a closure.\nPromoting a closure from an inner arena to the enclosing allocator\nrequires deep-copying the closure's captured cells, which the compiler\ndoes not yet support. Allowing it would leave the returned closure\npointing at captures freed when the inner arena is destroyed.\n\nFix: construct the closure outside the 'with arena \{ }' block, or\nreturn a non-closure value from the block and build the closure after."
     }
-    if code == "E1003" {
+    if code == PRIVATE_ITEM_ACCESS {
         return "E1003 -- PrivateItemAccess\n\nAn attempt was made to access a private (non-pub) item from another\nmodule.\n\nFix: either mark the item as 'pub' in its module, or use the\nmodule's public API instead.\n\n  // in math.bl\n  pub fn sqrt(x: Float) -> Float \{ ... \}  // accessible\n  fn helper() \{ ... \}                      // private"
     }
-    if code == "E1004" {
+    if code == VERSION_CONFLICT {
         return "E1004 -- VersionConflict\n\nTwo dependencies in the lockfile require different versions of the\nsame package. Blink enforces exactly one version per package.\n\n  myapp depends on http 0.5\n  auth 1.0 depends on http 0.6\n  → conflict: only one version of 'http' allowed\n\nFix: run 'blink update' to find a compatible version, or pin\ndependencies to use the same version in blink.toml."
     }
-    if code == "E1008" {
+    if code == INVALID_MODULE_ANNOTATION {
         return "E1008 -- InvalidModuleAnnotation\n\nThe @module annotation tried to move a file into a different package.\n@module can only set the module name to the parent package name —\nyou cannot use it to move a file into an unrelated package.\n\n  // auth/login.bl\n  @module(\"auth\")     // OK — matches parent package 'auth'\n  @module(\"billing\")  // E1008 — file is in 'auth', not 'billing'\n\nFix: use @module with the parent package name, or remove the annotation."
     }
-    if code == "E1009" {
+    if code == PACKAGE_ENTRY_NOT_FOUND {
         return "E1009 -- PackageEntryNotFound\n\nA bare `import <pkg>` resolved to a package whose entry file is\nmissing. The entry file is mandatory and must live at\n<pkg-root>/src/<name>.bl, where <name> is [package].name.\n\n  // libs/pg/blink.toml\n  // [package]\n  // name = \"pg\"\n  // libs/pg/src/pg.bl     <-- expected\n\nFix: create src/<name>.bl in the package, or correct the\n[package].name field in blink.toml."
     }
-    if code == "E1010" {
+    if code == ORPHAN_FILE {
         return "E1010 -- OrphanFile\n\nA source file with no enclosing blink.toml is not part of any\npackage. Bare external imports from such a file are not allowed —\nonly stdlib (std.*) and bundled (pkg.*) imports work.\n\n  // /tmp/foo.bl  (no blink.toml ancestor)\n  import mylib    // E1010 — orphan file\n\nFix: create a blink.toml in an ancestor directory to declare the\npackage, or import only std.* / pkg.* modules."
     }
-    if code == "E1011" {
+    if code == INVALID_PACKAGE_NAME {
         return "E1011 -- InvalidPackageName\n\nThe [package].name field violates the package-name grammar.\n[package].name must match [a-z][a-z0-9_]* — start with a lowercase\nletter, followed by lowercase letters, digits, or underscores.\nHyphens, dots, and uppercase letters are forbidden.\n\n  name = \"my_lib\"   // OK\n  name = \"My-Lib\"   // E1011 — uppercase + hyphen\n  name = \"1lib\"     // E1011 — leading digit\n\nFix: rename the package to satisfy the grammar."
     }
-    if code == "E1052" {
+    if code == PACKAGE_NOT_DECLARED {
         return "E1052 -- PackageNotDeclared\n\nA Tier 2 stdlib package was imported without declaring it in blink.toml.\nTier 2 packages (std.http, std.db, std.log, std.config, std.net) require\nexplicit dependency declaration.\n\n  // blink.toml\n  [dependencies]\n  std/http = \"0.1\"\n\n  // then in your code:\n  import std.http  // OK with declaration\n\nTier 1 packages (std.json, std.toml, etc.) are always available."
     }
-    if code == "E1015" {
+    if code == INLINE_MODULE_NOT_SUPPORTED {
         return "E1015 -- InlineModuleNotSupported\n\nInline modules (mod name \{ ... \}) are not supported in Blink.\nBlink uses file-based modules: one file = one module.\n\nFix: move the module contents into a separate file and use import.\n\n  // Instead of:\n  mod schema \{\n      fn validate() \{ ... \}\n  \}\n\n  // Create schema.bl with the contents and import it:\n  import schema\n  schema.validate()\n\nSee section 10.1 for details on Blink's module system."
     }
-    if code == "E1100" {
+    if code == UNEXPECTED_TOKEN {
         return "E1100 -- UnexpectedToken\n\nThe parser encountered a token it did not expect at this position.\n\nCommon causes:\n  - Missing or extra braces, parentheses, or brackets\n  - Incorrect syntax for the current context\n  - Using an operator in the wrong position\n\nFix: check the line and column indicated and look for syntax errors."
     }
-    if code == "E1101" {
+    if code == UNEXPECTED_TOKEN_STRING {
         return "E1101 -- UnexpectedToken in String\n\nThe parser encountered an unexpected token inside a string\ninterpolation.\n\nCommon causes:\n  - Malformed interpolation expression\n  - Unmatched braces inside a string\n\nFix: ensure interpolation expressions are valid Blink expressions."
     }
-    if code == "E1102" {
+    if code == UNEXPECTED_TOKEN_PATTERN {
         return "E1102 -- UnexpectedToken in Pattern\n\nThe parser encountered an unexpected token inside a match pattern.\n\nCommon causes:\n  - Invalid pattern syntax in a match arm\n  - Using expressions where a pattern is expected\n\nFix: use valid pattern syntax: literals, identifiers, enum variants,\nor wildcard '_'."
     }
-    if code == "E1103" {
+    if code == KEYWORD_AS_IDENTIFIER {
         return "E1103 -- KeywordAsIdentifier\n\nA language keyword was used where an identifier (variable or\nfunction name) was expected.\n\nKeywords: fn, let, if, else, match, while, return, type, trait,\nimport, pub, handler, effect, enum, for, in, mut, const, test\n\nFix: choose a different name that is not a reserved keyword.\n\n  let result = 42    // OK\n  let match = 42     // E1103: 'match' is a keyword"
     }
-    if code == "E1107" {
+    if code == EMPTY_BRACE_EXPR {
         return "E1107 -- EmptyBraceExpr\n\nEmpty braces were used in expression position. Blink does not have\nempty-brace map syntax.\n\nFix: use Map() to construct an empty map.\n\n  let m: Map[Str, Int] = Map()  // OK"
     }
-    if code == "E1108" {
+    if code == FILE_NOT_FOUND {
         return "E1108 -- FileNotFound / UnknownIntrinsic\n\nEither an #embed() referenced a file that does not exist, or an\nunknown compile-time intrinsic was used.\n\nFix: check that the file path is correct relative to the source\nfile, or use a supported intrinsic (#embed is currently the only one).\n\n  const data: Str = #embed(\"data.txt\")  // file must exist"
     }
-    if code == "E1109" {
+    if code == MUT_FIELD_NOT_SUPPORTED {
         return "E1109 -- MutFieldNotSupported\n\nThe 'mut' keyword was used on a struct field declaration. In Blink,\nmutability is a property of the binding, not the type or its fields.\nAll fields of a 'let mut' binding are mutable; all fields of a 'let'\nbinding are immutable.\n\nFix: remove 'mut' from the field and use 'let mut' when binding.\n\n  type Point \{ x: Float, y: Float \}\n  let mut p = Point \{ x: 1.0, y: 2.0 \}\n  p.x = 3.0  // OK — binding is mut"
     }
-    if code == "E1200" {
+    if code == MODULE_NOT_FOUND {
         return "E1200 -- ModuleNotFound\n\nAn import statement referenced a module that could not be found.\n\nCommon causes:\n  - Typo in the module name\n  - Missing file: the module's .bl file does not exist\n  - Incorrect path in the module hierarchy\n\nFix: verify the module name matches a .bl file in your project or\nthe standard library.\n\n  import math       // looks for lib/std/math.bl or src/math.bl\n  import pkg.audit  // looks for lib/pkg/audit.bl"
     }
-    if code == "W0501" {
+    if code == UNKNOWN_METHOD {
         return "W0501 -- UnknownMethod\n\nA method was called that could not be verified during type checking.\nThe code will still compile, but may produce a C error.\n\nCommon causes:\n  - The variable's type is not fully known at check time\n  - A typo in the method name\n\nFix: verify the method name and receiver type."
     }
-    if code == "W0550" {
+    if code == INCOMPLETE_STATE_RESTORE {
         return "W0550 -- IncompleteStateRestore\n\nA function call mutates global state but only some of the affected\nglobals are saved and restored around the call.\n\nCommon causes:\n  - Adding a new global to a function's write-set without updating\n    the save/restore pattern in the caller\n\nFix: save and restore all affected globals around the call, or\nverify the mutation is intentional."
     }
-    if code == "W0551" {
+    if code == UNRESTORED_MUTATION {
         return "W0551 -- UnrestoredMutation\n\nA function call mutates globals with no save/restore pattern, but\nthe enclosing function uses save/restore elsewhere. This suggests\nthe call may need save/restore too.\n\nCommon causes:\n  - Calling a function with broad side effects speculatively\n  - Forgetting to wrap the call in a save/restore block\n\nFix: if the call is speculative (may need to be rolled back), save\nand restore the affected globals."
     }
-    if code == "W0600" {
+    if code == UNUSED_VARIABLE {
         return "W0600 -- UnusedVariable\n\nA variable was declared but never read.\n\nCommon causes:\n  - Leftover variable from refactoring\n  - Variable assigned but result never used\n\nFix: remove the variable, or prefix its name with '_' to suppress\nthis warning.\n\n  let _unused = compute()  // OK -- prefixed with '_'"
     }
-    if code == "W0601" {
+    if code == SET_BUT_NOT_READ {
         return "W0601 -- SetButNotRead\n\nA variable was assigned a value that was never read before being\noverwritten or going out of scope.\n\nCommon causes:\n  - Redundant assignment before reassignment\n  - Leftover intermediate computation\n\nFix: remove the unused assignment, or prefix with '_' to suppress.\n\n  let mut x = compute()  // W0601: value never read\n  x = other()\n  io.println(x)"
     }
-    if code == "W0602" {
+    if code == UNUSED_IMPORT {
         return "W0602 -- UnusedImport\n\nA module was imported but no symbols from it are referenced.\n\nCommon causes:\n  - Leftover import from refactoring\n  - Import added for future use\n\nFix: remove the unused import statement.\n\n  import math    // W0602 if math.* never used\n  import strings // OK if strings.contains() is called"
     }
-    if code == "W0603" {
+    if code == SHADOWED_VARIABLE {
         return "W0603 -- ShadowedVariable\n\nA variable in an inner scope shadows a variable with the same name\nin an outer scope.\n\nCommon causes:\n  - Accidentally reusing a variable name from an enclosing scope\n  - Copy-paste without renaming\n\nFix: rename the inner variable, or prefix with '_' to suppress\nthis warning.\n\n  let x = 10\n  if true \{\n      let _x = 20  // OK -- prefixed with '_'\n  \}"
     }
-    if code == "W0700" {
+    if code == UNREACHABLE_CODE {
         return "W0700 -- UnreachableCode\n\nCode appears after an unconditional return, break, or continue\nstatement and will never execute.\n\nCommon causes:\n  - Leftover code from refactoring\n  - Early return added without removing subsequent code\n\nFix: remove the unreachable code or move it before the control\nflow statement."
     }
-    if code == "W0701" {
+    if code == ARENA_EFFECT_REDUNDANT {
         return "W0701 -- ArenaEffectRedundant\n\nA function declares '! Arena' but every Arena-effectful call in its\nbody is already contained inside a 'with arena \{ }' block. Because\n'with arena \{ }' is the escape boundary for the '! Arena' marker,\nthe outer annotation adds no information.\n\nFix: remove '! Arena' from the function signature, or add\n@allow(ArenaEffectRedundant) if the annotation is intentional for\ndocumentation or API stability.\n\n  fn wrap() -> Int \{                     // OK -- no marker needed\n      with arena \{ consume([1, 2]) }\n  \}\n\n  fn wrap() -> Int ! Arena \{             // W0701\n      with arena \{ consume([1, 2]) }\n  \}"
     }
-    if code == "W0800" {
+    if code == UNAUDITED_FFI {
         return "W0800 -- UnauditedFFI\n\nAn @ffi function is not marked @trusted, meaning it has not been\naudited for safety.\n\nFix: audit the foreign function for memory safety and correctness,\nthen add @trusted to suppress this warning.\n\n  @ffi(\"puts\")\n  @trusted\n  fn c_puts(s: Ptr[U8]) -> Int ! FFI \{ \}"
     }
-    if code == "E0801" {
+    if code == PUB_FFI {
         return "E0801 -- PubFFI\n\nAn @ffi function was declared as pub. FFI functions are unsafe and\nshould not be exposed in a module's public API.\n\nFix: remove 'pub' and wrap the FFI call in a safe public function.\n\n  @ffi(\"strlen\")\n  @trusted\n  fn c_strlen(s: Ptr[U8]) -> Int ! FFI \{ \}\n\n  pub fn string_length(s: Str) -> Int ! FFI \{\n      c_strlen(s.as_ptr())\n  \}"
     }
-    if code == "E0802" {
+    if code == FFI_NO_EFFECTS {
         return "E0802 -- FFINoEffects\n\nAn @ffi function does not declare any effects. FFI calls are\ninherently side-effectful and must declare their effects.\n\nFix: add '! FFI' or appropriate effects to the function signature.\n\n  @ffi(\"puts\")\n  @trusted\n  fn c_puts(s: Ptr[U8]) -> Int ! FFI \{ \}"
     }
-    if code == "E0803" {
+    if code == CONTRACT_ON_FFI {
         return "E0803 -- ContractOnFFI\n\nA @requires or @ensures annotation was used on an @ffi function.\nContracts cannot verify foreign code behavior.\n\nFix: remove the contract annotation from the FFI function. If you\nneed contracts, add them to a safe wrapper function instead.\n\n  @ffi(\"sqrt\")\n  @trusted\n  fn c_sqrt(x: Float) -> Float ! FFI \{ \}\n\n  @requires(x >= 0.0)\n  pub fn safe_sqrt(x: Float) -> Float ! FFI \{\n      c_sqrt(x)\n  \}"
     }
-    if code == "E0810" {
+    if code == INVALID_PTR_TYPE {
         return "E0810 -- InvalidPtrType\n\nPtr[T] was used with an invalid type parameter. Only FFI-compatible\ntypes are allowed inside Ptr.\n\nValid types: Void, U8, U16, U32, U64, I8, I16, I32, I64, Int,\nFloat, Ptr\n\nFix: use one of the valid FFI-compatible types.\n\n  fn good(p: Ptr[U8]) ! FFI \{ \}   // OK\n  fn bad(p: Ptr[Str]) ! FFI \{ \}    // E0810: Str is not valid"
     }
-    if code == "E0811" {
+    if code == PTR_OUTSIDE_FFI {
         return "E0811 -- PtrOutsideFFI\n\nPtr[T] was used in a function that is not marked @ffi. Pointer\ntypes are only valid in FFI contexts.\n\nFix: add @ffi to the function, or use a safe wrapper.\n\n  @ffi(\"malloc\")\n  @trusted\n  fn c_malloc(size: Int) -> Ptr[Void] ! FFI \{ \}"
     }
-    if code == "W0812" {
+    if code == MISSING_CANONICAL_HEADER {
         return "W0812 -- MissingCanonicalHeader\n\nAn @ffi.struct annotation declares a canonical header that is not\nlisted in any [native-dependencies].<dep>.headers entry of\nblink.toml. Without that declaration the build cannot guarantee the\nheader will be available on the target system, so layout asserts\nmay fail to compile out-of-tree.\n\nFix: list the header in blink.toml:\n\n  [native-dependencies]\n  libname = \{ system = true, headers = [\"poll.h\"] \}\n\nUnder --strict-struct-layout the warning is escalated to error."
     }
-    if code == "E0812" {
+    if code == FFI_STRUCT_GC_FIELD {
         return "E0812 -- FfiStructGcField\n\nAn @ffi.struct field uses a GC-managed or non-FFI-compatible type.\n@ffi.struct types must mirror C structs exactly, so fields must use\nsized FFI-compatible types only.\n\nValid field types: I8/I16/I32/I64, U8/U16/U32/U64, Int, Float, F32,\nF64, Bool, and (in future) other @ffi.struct types.\n\nRejected: Str, Bytes, List, Map, Set, Result, Option, traits, and\nany user-defined type without @ffi.struct.\n\nFix: use a sized integer/float/bool type, or wrap the GC-managed\nvalue in a Blink-side struct outside the @ffi boundary.\n\n  @ffi.struct(header: \"poll.h\", name: \"pollfd\")\n  pub type Pollfd \{\n      fd: I32,           // OK\n      events: I16,       // OK\n      revents: I16,      // OK\n      // name: Str,      // E0812\n  \}"
     }
-    if code == "E0813" {
+    if code == FFI_OFFSET_ON_SINGLETON {
         return "E0813 -- FfiOffsetOnSingleton\n\nPtr.offset(i) was called on a Ptr produced by scope.alloc[T](),\nwhich allocates a single cell. Pointer arithmetic past cell 0 is\nundefined behavior.\n\nFix: allocate an array via scope.alloc_n[T](n), then use offset.\n\n  let p: Ptr[Pollfd] = scope.alloc_n(8)\n  let q = p.offset(3)   // OK"
     }
-    if code == "E0814" {
+    if code == BYTES_GROW_IN_WITH_PTR {
         return "E0814 -- BytesGrowInWithPtr\n\nA growth-effecting method (push/append/concat/extend/clear/\ntruncate/resize/write_*_le/be) was called on the Bytes receiver\ninside its with_ptr closure. Growth would invalidate the pinned\nPtr[U8] aliasing the GC-managed buffer.\n\nFix: move the growth call outside the with_ptr closure.\n\n  b.with_ptr(fn(p) \{ c_read(fd, p, n) })  // OK\n  b.push(0)                                // OK after closure"
     }
-    if code == "E0815" {
+    if code == PINNED_BYTES_ESCAPE {
         return "E0815 -- PinnedBytesEscape\n\nThe pinned Bytes receiver was passed as an argument inside its\nwith_ptr closure. Helper-function bodies are out of scope for the\nsyntactic no-grow check, so escapes are forbidden.\n\nFix: pass the Ptr[U8] 'p' or an integer slice instead.\n\n  b.with_ptr(fn(p) \{ helper_taking_ptr(p, b.len()) })   // OK"
     }
-    if code == "E0816" {
+    if code == WITH_PTR_BODY_TOO_COMPLEX {
         return "E0816 -- WithPtrBodyTooComplex\n\nBytes.with_ptr currently requires the closure body to be a single\nexpression so the call site can be inlined safely. Multi-statement\nbodies are not supported.\n\nFix: extract complex logic into a helper function that takes\nPtr[U8] and call it from the closure body."
     }
-    if code == "E0817" {
+    if code == BYTES_PTR_CAST_FORBIDDEN {
         return "E0817 -- BytesPtrCastForbidden\n\nBytes cannot be cast or coerced to Ptr[U8] outside a with_ptr\nclosure. Bytes is a GC-managed buffer and may be relocated by\nthe garbage collector; raw Ptr[U8] aliases would dangle.\n\nFix: use Bytes.with_ptr to pin the buffer for the duration of\nthe call, and pass the pinned pointer to the FFI:\n\n  b.with_ptr(fn(p) \{ c_read(fd, p, b.len()) })   // OK"
     }
-    if code == "E0820" {
+    if code == MISSING_NATIVE_DEP {
         return "E0820 -- MissingNativeDep\n\nAn @ffi annotation references a C library that is not declared in\nthe [native-dependencies] section of blink.toml.\n\nFix: add the library to blink.toml:\n\n  [native-dependencies]\n  libname = \{ system = true \}"
     }
-    if code == "E0821" {
+    if code == NATIVE_DEP_UNAVAILABLE_CROSS {
         return "E0821 -- NativeDepUnavailableCrossTarget\n\nA native dependency declared as system-only cannot be resolved for\na cross-compilation target. Cross-compilation requires vendored\nsource or a static archive.\n\nFix: provide vendored source:\n  libname = \{ path = \"vendor/libname.c\" \}\n\nOr explicitly opt in to dynamic linking on the target:\n  libname = \{ system = true, link = \"dynamic\" \}"
     }
-    if code == "W2000" {
+    if code == DEPRECATED_USAGE {
         return "W2000 -- DeprecatedUsage\n\nA function or type marked @deprecated was used.\n\nThe @deprecated annotation signals that an API is scheduled for\nremoval. The warning includes the deprecation edition (if known)\nand a suggested replacement.\n\nFix: migrate to the replacement API shown in the help message.\n\n  @deprecated(replacement: \"new_fn\")\n  fn old_fn() \{ \}\n\n  fn main() \{\n      old_fn()   // W2000: use of deprecated function 'old_fn'\n                 // help: use 'new_fn' instead\n  \}"
     }
     ""

--- a/src/escape.bl
+++ b/src/escape.bl
@@ -11,8 +11,10 @@ import diagnostics.{
     Diag, diag_error_at, diag_warn_at, diag_set_last_fix,
     diag_source_file, diag_file_for_node,
     diag_push_allows, diag_clear_allows,
+    ARENA_VALUE_ESCAPES, ARENA_TYPE_CONTAINS_CYCLE, ARENA_EFFECT_REDUNDANT,
 }
 import typecheck.{tc_fn_has_effect}
+import codegen_types.{list_contains_str}
 
 // Arena escape analysis: classifies allocations inside `with arena { }` as
 // promoted (tail-position return) or escaped (emits E0700).
@@ -157,7 +159,7 @@ fn check_promote_cycle(node: Int, type_name: Str) ! Diag.Report {
     let saved = diag_source_file
     diag_source_file = diag_file_for_node(node)
     diag_error_at(
-        "ArenaTypeContainsCycle", "E0701",
+        "ArenaTypeContainsCycle", ARENA_TYPE_CONTAINS_CYCLE,
         "type '{type_name}' contains a cyclic reference; arena promotion cannot walk cyclic structures",
         node,
         "allocate this value outside the 'with arena \{ }' block, or break the cycle"
@@ -325,7 +327,7 @@ fn emit_escape(node: Int, category: Str) ! Diag.Report {
     diag_source_file = diag_file_for_node(node)
     let target = ea_promotion_target()
     diag_error_at(
-        "ArenaValueEscapes", "E0700",
+        "ArenaValueEscapes", ARENA_VALUE_ESCAPES,
         "value allocated in 'with arena \{ }' escapes via {category}; would be promoted into: {target}",
         node,
         "copy the value explicitly before it leaves the arena scope, or remove '! Arena' and let it be GC-managed"
@@ -872,7 +874,7 @@ fn cc_scan(node: Int, locals: List[Str]) ! Diag.Report {
     let k = node_kind(node)
     if k == NodeKind.Ident {
         let n = node_name(node)
-        if ident_in_list(n, locals) == 0 {
+        if list_contains_str(locals, n) == 0 {
             if ea_is_local_anywhere(n) != 0 {
                 emit_escape(node, "closure capture")
             }
@@ -913,15 +915,6 @@ fn check_closure_captures(closure_node: Int) ! Diag.Report {
         }
     }
     cc_scan(body, pnames)
-}
-
-fn ident_in_list(name: Str, names: List[Str]) -> Int {
-    let mut i = 0
-    while i < names.len() {
-        if names.get(i).unwrap() == name { return 1 }
-        i = i + 1
-    }
-    0
 }
 
 @allow(UnrestoredMutation, IncompleteStateRestore)
@@ -965,7 +958,7 @@ fn check_redundant_arena_effect(fn_node: Int, arena_eff: Int) ! Diag.Report {
     if ea_fn_arena_bare_call != 0 { return }
     let fname = node_name(fn_node)
     diag_warn_at(
-        "ArenaEffectRedundant", "W0701",
+        "ArenaEffectRedundant", ARENA_EFFECT_REDUNDANT,
         "function '{fname}' declares '! Arena' but every Arena-effectful call is already contained inside 'with arena \{ }' — the marker is redundant",
         arena_eff,
         "remove '! Arena' from the signature of '{fname}'"

--- a/src/mutation_analysis.bl
+++ b/src/mutation_analysis.bl
@@ -10,6 +10,7 @@ import parser.{
 import diagnostics.{
     Diag, diag_error_at, diag_source_file, diag_file_for_node,
     diag_push_allows, diag_clear_allows,
+    INCOMPLETE_STATE_RESTORE, UNRESTORED_MUTATION,
 }
 
 // mutation_analysis.bl — Tier 1 write-set inference for Blink modules
@@ -580,7 +581,7 @@ fn sr_check_call(call_node: Int, callee_name: Str) ! Diag.Report {
             ui = ui + 1
         }
         diag_error_at(
-            "IncompleteStateRestore", "W0550",
+            "IncompleteStateRestore", INCOMPLETE_STATE_RESTORE,
             "call to '{callee_name}' in '{sr_current_fn}' mutates [{missing}] which are not saved/restored (write-set: {wcount} globals, saved: {saved_count})",
             call_node,
             "save and restore [{missing}] around this call, or verify the mutation is intentional"
@@ -598,7 +599,7 @@ fn sr_check_call(call_node: Int, callee_name: Str) ! Diag.Report {
             wi = wi + 1
         }
         diag_error_at(
-            "UnrestoredMutation", "W0551",
+            "UnrestoredMutation", UNRESTORED_MUTATION,
             "call to '{callee_name}' in '{sr_current_fn}' mutates [{all_writes}] with no save/restore pattern",
             call_node,
             "if this call is speculative, save/restore affected globals"

--- a/src/parser.bl
+++ b/src/parser.bl
@@ -1,7 +1,13 @@
 import tokens.{TokenKind, is_keyword, token_kind_name}
 import ast.{NodeKind, AstNode}
 import lexer.{tokens}
-import diagnostics.{Diag, diag_error, diag_error_range}
+import diagnostics.{
+    Diag, diag_error, diag_error_range,
+    INLINE_MODULE_NOT_SUPPORTED, UNEXPECTED_ANNOTATION, UNEXPECTED_TOKEN,
+    UNEXPECTED_TOKEN_STRING, UNEXPECTED_TOKEN_PATTERN, KEYWORD_AS_IDENTIFIER,
+    EMPTY_BRACE_EXPR, UNKNOWN_INTRINSIC, MUT_FIELD_NOT_SUPPORTED,
+    INVALID_STRING_BACKED_ENUM,
+}
 
 effect Parse {
     effect Advance
@@ -513,7 +519,7 @@ fn advance_value() -> Str ! Parse.Advance {
 
 fn expect(kind: TokenKind) -> Int ! Parse.Advance, Diag.Report {
     if peek_kind() != kind {
-        diag_error_range("UnexpectedToken", "E1100", "expected {token_kind_name(kind)}, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+        diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "expected {token_kind_name(kind)}, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
     }
     advance()
 }
@@ -521,9 +527,9 @@ fn expect(kind: TokenKind) -> Int ! Parse.Advance, Diag.Report {
 fn expect_value(kind: TokenKind) -> Str ! Parse.Advance, Diag.Report {
     if peek_kind() != kind {
         if kind == TokenKind.Ident && is_keyword(peek_kind()) {
-            diag_error_range("KeywordAsIdentifier", "E1103", "'{peek_value()}' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+            diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'{peek_value()}' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         } else {
-            diag_error_range("UnexpectedToken", "E1100", "expected {token_kind_name(kind)}, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "expected {token_kind_name(kind)}, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
         }
     }
     advance_value()
@@ -778,7 +784,7 @@ pub fn parse_program() -> Int ! Parse, Diag.Report {
                 attach_pending_annotations(imp)
                 import_nodes.push(imp)
             } else {
-                diag_error_range("UnexpectedToken", "E1100", "expected fn, type, trait, or effect after pub", peek_line(), peek_col(), peek_end_col(), "")
+                diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "expected fn, type, trait, or effect after pub", peek_line(), peek_col(), peek_end_col(), "")
                 advance()
             }
         } else if at(TokenKind.Effect) {
@@ -814,9 +820,9 @@ pub fn parse_program() -> Int ! Parse, Diag.Report {
                     advance()
                 }
             }
-            diag_error("InlineModuleNotSupported", "E1015", "inline modules are not supported; create a separate file and use 'import' instead (see section 10.1.1)", mod_line, mod_col, "Blink uses file-based modules: one file = one module")
+            diag_error("InlineModuleNotSupported", INLINE_MODULE_NOT_SUPPORTED, "inline modules are not supported; create a separate file and use 'import' instead (see section 10.1.1)", mod_line, mod_col, "Blink uses file-based modules: one file = one module")
         } else {
-            diag_error_range("UnexpectedToken", "E1100", "unexpected token at top level: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "unexpected token at top level: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
             advance()
         }
         skip_newlines_and_comments()
@@ -991,7 +997,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                 where_expr = parse_expr()
                 expect(TokenKind.RParen)
             } else {
-                diag_error_range("UnexpectedAnnotation", "E1100", "only @where is supported on type aliases, got @{ann_name}", peek_line(), peek_col(), peek_end_col(), "use @where(predicate) to add a refinement constraint")
+                diag_error_range("UnexpectedAnnotation", UNEXPECTED_ANNOTATION, "only @where is supported on type aliases, got @{ann_name}", peek_line(), peek_col(), peek_end_col(), "use @where(predicate) to add a refinement constraint")
             }
         }
         let td = node_count()
@@ -1035,7 +1041,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                 break
             }
             if at(TokenKind.Mut) {
-                diag_error_range("MutFieldNotSupported", "E1109", "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
+                diag_error_range("MutFieldNotSupported", MUT_FIELD_NOT_SUPPORTED, "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
                 while at(TokenKind.Mut) {
                     advance()
                 }
@@ -1066,7 +1072,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                 if !at(TokenKind.RParen) {
                     vflds = new_sublist()
                     if at(TokenKind.Mut) {
-                        diag_error_range("MutFieldNotSupported", "E1109", "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
+                        diag_error_range("MutFieldNotSupported", MUT_FIELD_NOT_SUPPORTED, "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
                         while at(TokenKind.Mut) {
                             advance()
                         }
@@ -1088,7 +1094,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                                 break
                             }
                             if at(TokenKind.Mut) {
-                                diag_error_range("MutFieldNotSupported", "E1109", "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
+                                diag_error_range("MutFieldNotSupported", MUT_FIELD_NOT_SUPPORTED, "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
                                 while at(TokenKind.Mut) {
                                     advance()
                                 }
@@ -1135,7 +1141,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                 let mut vflds = new_sublist()
                 while !at(TokenKind.RBrace) && !at(TokenKind.EOF) {
                     if at(TokenKind.Mut) {
-                        diag_error_range("MutFieldNotSupported", "E1109", "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
+                        diag_error_range("MutFieldNotSupported", MUT_FIELD_NOT_SUPPORTED, "'mut' is not valid on struct fields — mutability is controlled by the binding (let mut)", peek_line(), peek_col(), peek_end_col(), "remove 'mut' from the field declaration; use 'let mut' when binding the struct")
                         while at(TokenKind.Mut) {
                             advance()
                         }
@@ -1176,7 +1182,7 @@ fn parse_type_def() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
                         let part = sublist_get(parts_sl, 0)
                         tv_str = node_str_val(part)
                     } else {
-                        diag_error_range("InvalidStringBackedEnum", "E1200", "string-backed enum values must be plain string literals", peek_line(), peek_col(), peek_end_col(), "use a simple string like = \"value\"")
+                        diag_error_range("InvalidStringBackedEnum", INVALID_STRING_BACKED_ENUM, "string-backed enum values must be plain string literals", peek_line(), peek_col(), peek_end_col(), "use a simple string like = \"value\"")
                     }
                 }
                 let tv = node_count()
@@ -1787,7 +1793,7 @@ fn parse_with_item() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
     if at(TokenKind.Equals) {
         let mut lhs_name = ""
         if node_kind(expr) != NodeKind.Ident {
-            diag_error_range("UnexpectedToken", "E1100", "left side of `=` in with-clause must be an identifier", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "left side of `=` in with-clause must be an identifier", peek_line(), peek_col(), peek_end_col(), "")
         } else {
             lhs_name = node_name(expr)
         }
@@ -1795,7 +1801,7 @@ fn parse_with_item() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
         skip_newlines_and_comments()
         let rhs = parse_expr()
         if !at(TokenKind.As) {
-            diag_error_range("UnexpectedToken", "E1100", "expected `as <name>` after `{lhs_name} = <expr>` in with-clause, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "expected `as <name>` after `{lhs_name} = <expr>` in with-clause, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
             let wr = node_count()
             nodes.push(AstNode {
                 kind: NodeKind.WithResource, value: rhs, name: lhs_name,
@@ -1808,11 +1814,11 @@ fn parse_with_item() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
         if at(TokenKind.Ident) {
             binding = advance_value()
         } else {
-            diag_error_range("UnexpectedToken", "E1100", "expected identifier after `as` in with-clause, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "expected identifier after `as` in with-clause, got {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
             binding = lhs_name
         }
         if binding != lhs_name && lhs_name != "" {
-            diag_error_range("UnexpectedToken", "E1100", "with-clause binding name `{binding}` must match left side `{lhs_name}`", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "with-clause binding name `{binding}` must match left side `{lhs_name}`", peek_line(), peek_col(), peek_end_col(), "")
         }
         let wr = node_count()
         nodes.push(AstNode {
@@ -2076,7 +2082,7 @@ fn parse_embed_expr() -> Int ! Parse.Advance, Parse.Build, Diag.Report {
     expect(TokenKind.Hash)
     let intrinsic = expect_value(TokenKind.Ident)
     if intrinsic != "embed" {
-        diag_error_range("UnknownIntrinsic", "E1108", "unknown compile-time intrinsic '#{intrinsic}' (only #embed is supported)", peek_line(), peek_col(), peek_end_col(), "")
+        diag_error_range("UnknownIntrinsic", UNKNOWN_INTRINSIC, "unknown compile-time intrinsic '#{intrinsic}' (only #embed is supported)", peek_line(), peek_col(), peek_end_col(), "")
         let nd = new_node(NodeKind.IntLit)
         return nd
     }
@@ -2636,7 +2642,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
         if next_ok {
             return parse_match_expr()
         }
-        diag_error_range("KeywordAsIdentifier", "E1103", "'match' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'match' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: "match", line: pm_line, col: pm_col })
@@ -2648,7 +2654,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
         if next_ok {
             return parse_if_expr()
         }
-        diag_error_range("KeywordAsIdentifier", "E1103", "'if' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'if' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: "if", line: pm_line, col: pm_col })
@@ -2666,7 +2672,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
         if next_pos < tokens.len() && peek_kind_at(next_pos) == TokenKind.LParen {
             return parse_closure()
         }
-        diag_error_range("KeywordAsIdentifier", "E1103", "'fn' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'fn' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: "fn", line: pm_line, col: pm_col })
@@ -2681,7 +2687,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
             return parse_handler_expr()
         }
         // Keyword used as identifier — emit error and treat as ident
-        diag_error_range("KeywordAsIdentifier", "E1103", "'handler' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'handler' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: "handler", line: pm_line, col: pm_col })
@@ -2694,7 +2700,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
         if next_ok {
             return parse_with_block()
         }
-        diag_error_range("KeywordAsIdentifier", "E1103", "'with' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'with' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: "with", line: pm_line, col: pm_col })
@@ -2802,7 +2808,7 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
 
     if at(TokenKind.LBrace) {
         if tokens.get(pos + 1).unwrap().kind == TokenKind.RBrace {
-            diag_error_range("EmptyBraceExpr", "E1107", "empty '\{\}' is not a valid expression — use Map() for empty maps", peek_line(), peek_col(), peek_end_col(), "replace '\{\}' with 'Map()'")
+            diag_error_range("EmptyBraceExpr", EMPTY_BRACE_EXPR, "empty '\{\}' is not a valid expression — use Map() for empty maps", peek_line(), peek_col(), peek_end_col(), "replace '\{\}' with 'Map()'")
             advance()
             advance()
             return new_node(NodeKind.IntLit)
@@ -2812,14 +2818,14 @@ fn parse_primary() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
 
     if is_keyword(peek_kind()) {
         let kw_name = peek_value()
-        diag_error_range("KeywordAsIdentifier", "E1103", "'{kw_name}' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
+        diag_error_range("KeywordAsIdentifier", KEYWORD_AS_IDENTIFIER, "'{kw_name}' is a keyword and cannot be used as an identifier", peek_line(), peek_col(), peek_end_col(), "use a different name")
         advance()
         let nd = node_count()
         nodes.push(AstNode { kind: NodeKind.Ident, name: kw_name, line: pm_line, col: pm_col })
         return nd
     }
 
-    diag_error_range("UnexpectedToken", "E1100", "unexpected token {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+    diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN, "unexpected token {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
     advance()
     new_node(NodeKind.IntLit)
 }
@@ -2914,7 +2920,7 @@ fn parse_interp_string() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
             sublist_push(parts, parse_expr())
             expect(TokenKind.InterpEnd)
         } else {
-            diag_error_range("UnexpectedToken", "E1101", "unexpected token in string: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+            diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN_STRING, "unexpected token in string: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
             advance()
         }
     }
@@ -3259,7 +3265,7 @@ fn parse_single_pattern() -> Int ! Diag.Report, Parse.Advance, Parse.Build {
         nodes.push(AstNode { kind: NodeKind.IdentPattern, name: name, line: sp_line, col: sp_col })
         return nd
     }
-    diag_error_range("UnexpectedToken", "E1102", "unexpected token in pattern: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
+    diag_error_range("UnexpectedToken", UNEXPECTED_TOKEN_PATTERN, "unexpected token in pattern: {token_kind_name(peek_kind())}", peek_line(), peek_col(), peek_end_col(), "")
     advance()
     let nd = node_count()
     nodes.push(AstNode { kind: NodeKind.WildcardPattern, line: sp_line, col: sp_col })

--- a/src/typecheck.bl
+++ b/src/typecheck.bl
@@ -14,6 +14,19 @@ import parser.{
 import diagnostics.{
     Diag, diag_clear_allows, diag_error_at, diag_error_no_loc,
     diag_push_allows, diag_warn_at,
+    TYPE_ERROR, CAPABILITY_BUDGET, QM_INVALID_OPERAND, UNDEFINED_FUNCTION,
+    UNDEFINED_VARIABLE, UNKNOWN_TYPE, QM_RESULT_IN_NON_RESULT,
+    QM_OPTION_IN_NON_OPTION, QM_ERROR_MISMATCH,
+    PUB_FFI, FFI_NO_EFFECTS, CONTRACT_ON_FFI, INVALID_PTR_TYPE,
+    PTR_OUTSIDE_FFI, FFI_STRUCT_GC_FIELD, BYTES_GROW_IN_WITH_PTR,
+    PINNED_BYTES_ESCAPE, BYTES_PTR_CAST_FORBIDDEN,
+    TRAIT_CONTRACT_900, TRAIT_CONTRACT_901, TRAIT_CONTRACT_902,
+    TRAIT_CONTRACT_903, TRAIT_CONTRACT_904, TRAIT_CONTRACT_905,
+    TRAIT_CONTRACT_906,
+    PRIVATE_ITEM_ACCESS, AMBIGUOUS_IMPORT, IMPORT_NOT_SELECTED,
+    MODULE_QUALIFIED_TYPE,
+    UNKNOWN_METHOD, UNUSED_VARIABLE, SET_BUT_NOT_READ, SHADOWED_VARIABLE,
+    BITWISE_PRECEDENCE, UNREACHABLE_CODE, UNAUDITED_FFI, DEPRECATED_USAGE,
 }
 
 effect TypeCheck {
@@ -399,12 +412,12 @@ fn instantiate_return_type(sig: Int, args_sl: Int) -> Int ! TypeCheck.Resolve, T
 
 fn tc_error(msg: Str) ! TypeCheck.Report, Diag.Report {
     tc_errors.push(msg)
-    diag_error_no_loc("TypeError", "E0300", msg, "")
+    diag_error_no_loc("TypeError", TYPE_ERROR, msg, "")
 }
 
 fn tc_error_at(msg: Str, node_id: Int) ! TypeCheck.Report, Diag.Report {
     tc_errors.push(msg)
-    diag_error_at("TypeError", "E0300", msg, node_id, "")
+    diag_error_at("TypeError", TYPE_ERROR, msg, node_id, "")
 }
 
 fn tc_warn(msg: Str) ! TypeCheck.Report {
@@ -529,7 +542,7 @@ fn register_struct_type(td: Int) ! TypeCheck.Register, TypeCheck.Resolve, Diag.R
             }
             if is_ffi_struct != 0 {
                 if is_ffi_struct_field_type(ftype_ann_name) == 0 {
-                    diag_error_at("FfiStructGcField", "E0812", "@ffi.struct field '{fname}' uses non-FFI type '{ftype_ann_name}' — only sized FFI-compatible types (I8/I16/I32/I64, U8/U16/U32/U64, Int, Float, F32, F64, Bool) and other @ffi.struct types are allowed", f, "use a sized integer/float/bool type or another @ffi.struct type")
+                    diag_error_at("FfiStructGcField", FFI_STRUCT_GC_FIELD, "@ffi.struct field '{fname}' uses non-FFI type '{ftype_ann_name}' — only sized FFI-compatible types (I8/I16/I32/I64, U8/U16/U32/U64, Int, Float, F32, F64, Bool) and other @ffi.struct types are allowed", f, "use a sized integer/float/bool type or another @ffi.struct type")
                 }
             }
             i = i + 1
@@ -693,7 +706,7 @@ fn check_deprecated_fn(fn_name: Str, call_node: Int) ! Diag.Report {
     if replacement != "" {
         help = "use '{replacement}' instead"
     }
-    diag_warn_at("DeprecatedUsage", "W2000", msg, call_node, help)
+    diag_warn_at("DeprecatedUsage", DEPRECATED_USAGE, msg, call_node, help)
 }
 
 fn check_deprecated_type(type_name: Str, usage_node: Int) ! Diag.Report {
@@ -712,7 +725,7 @@ fn check_deprecated_type(type_name: Str, usage_node: Int) ! Diag.Report {
     if replacement != "" {
         help = "use '{replacement}' instead"
     }
-    diag_warn_at("DeprecatedUsage", "W2000", msg, usage_node, help)
+    diag_warn_at("DeprecatedUsage", DEPRECATED_USAGE, msg, usage_node, help)
 }
 
 fn is_valid_ptr_inner(name: Str) -> Int {
@@ -728,14 +741,14 @@ fn check_ptr_in_type_ann(ann_node: Int, has_ffi: Int) ! Diag.Report {
     let name = node_name(ann_node)
     if name == "Ptr" {
         if has_ffi == 0 {
-            diag_error_at("PtrOutsideFFI", "E0811", "Ptr[T] type can only be used in @ffi functions or @trusted blocks", ann_node, "add @ffi annotation to the function or wrap usage in @trusted")
+            diag_error_at("PtrOutsideFFI", PTR_OUTSIDE_FFI, "Ptr[T] type can only be used in @ffi functions or @trusted blocks", ann_node, "add @ffi annotation to the function or wrap usage in @trusted")
         }
         let elems_sl = node_elements(ann_node)
         if elems_sl != -1 && sublist_length(elems_sl) > 0 {
             let inner = sublist_get(elems_sl, 0)
             let inner_name = node_name(inner)
             if is_valid_ptr_inner(inner_name) == 0 {
-                diag_error_at("InvalidPtrType", "E0810", "invalid Ptr type parameter '{inner_name}' — only Void, U8-U64, I8-I64, Int, Float, Ptr are allowed", inner, "use a valid FFI-compatible type")
+                diag_error_at("InvalidPtrType", INVALID_PTR_TYPE, "invalid Ptr type parameter '{inner_name}' — only Void, U8-U64, I8-I64, Int, Float, Ptr are allowed", inner, "use a valid FFI-compatible type")
             }
         }
         return
@@ -752,7 +765,7 @@ fn check_ptr_in_type_ann(ann_node: Int, has_ffi: Int) ! Diag.Report {
 
 fn check_ptr_in_type_name(type_name: Str, node: Int, has_ffi: Int) ! Diag.Report {
     if type_name == "Ptr" && has_ffi == 0 {
-        diag_error_at("PtrOutsideFFI", "E0811", "Ptr[T] type can only be used in @ffi functions or @trusted blocks", node, "add @ffi annotation to the function or wrap usage in @trusted")
+        diag_error_at("PtrOutsideFFI", PTR_OUTSIDE_FFI, "Ptr[T] type can only be used in @ffi functions or @trusted blocks", node, "add @ffi annotation to the function or wrap usage in @trusted")
     }
 }
 
@@ -768,20 +781,20 @@ fn validate_ffi_fn(fn_node: Int) ! Diag.Report {
 
     if has_ffi != 0 {
         if node_is_pub(fn_node) != 0 && has_trusted == 0 {
-            diag_error_at("PubFFI", "E0801", "FFI function '{name}' must not be pub — FFI functions are unsafe and should be wrapped", ffi_node, "remove 'pub' or add @trusted to mark it as audited")
+            diag_error_at("PubFFI", PUB_FFI, "FFI function '{name}' must not be pub — FFI functions are unsafe and should be wrapped", ffi_node, "remove 'pub' or add @trusted to mark it as audited")
         }
         let effects_sl = node_effects(fn_node)
         if effects_sl == -1 || sublist_length(effects_sl) == 0 {
-            diag_error_at("FFINoEffects", "E0802", "FFI function '{name}' must declare effects — FFI calls are side-effectful", ffi_node, "add '! FFI' or appropriate effects to the function signature")
+            diag_error_at("FFINoEffects", FFI_NO_EFFECTS, "FFI function '{name}' must declare effects — FFI calls are side-effectful", ffi_node, "add '! FFI' or appropriate effects to the function signature")
         }
         if has_requires != 0 {
-            diag_error_at("ContractOnFFI", "E0803", "@requires cannot be used on FFI function '{name}' — contracts cannot verify foreign code", requires_node, "remove @requires from the FFI function")
+            diag_error_at("ContractOnFFI", CONTRACT_ON_FFI, "@requires cannot be used on FFI function '{name}' — contracts cannot verify foreign code", requires_node, "remove @requires from the FFI function")
         }
         if has_ensures != 0 {
-            diag_error_at("ContractOnFFI", "E0803", "@ensures cannot be used on FFI function '{name}' — contracts cannot verify foreign code", ensures_node, "remove @ensures from the FFI function")
+            diag_error_at("ContractOnFFI", CONTRACT_ON_FFI, "@ensures cannot be used on FFI function '{name}' — contracts cannot verify foreign code", ensures_node, "remove @ensures from the FFI function")
         }
         if has_trusted == 0 {
-            diag_warn_at("UnauditedFFI", "W0800", "FFI function '{name}' is not marked @trusted — consider auditing and adding @trusted", ffi_node, "add @trusted after auditing the foreign function")
+            diag_warn_at("UnauditedFFI", UNAUDITED_FFI, "FFI function '{name}' is not marked @trusted — consider auditing and adding @trusted", ffi_node, "add @trusted after auditing the foreign function")
         }
     }
 
@@ -808,7 +821,7 @@ fn validate_ffi_fn(fn_node: Int) ! Diag.Report {
     } else {
         let ret_str = node_return_type(fn_node)
         if ret_str == "Ptr" && has_ffi == 0 {
-            diag_error_at("PtrOutsideFFI", "E0811", "Ptr[T] type can only be used in @ffi functions or @trusted blocks", fn_node, "add @ffi annotation to the function or wrap usage in @trusted")
+            diag_error_at("PtrOutsideFFI", PTR_OUTSIDE_FFI, "Ptr[T] type can only be used in @ffi functions or @trusted blocks", fn_node, "add @ffi annotation to the function or wrap usage in @trusted")
         }
     }
 }
@@ -856,7 +869,7 @@ fn validate_capabilities_budget(program: Int, fns_sl: Int) ! Diag.Report {
                         bi = bi + 1
                     }
                     if allowed == 0 {
-                        diag_error_at("CapabilityBudgetExceeded", "E0501", "function '{fn_name}' uses effect '{eff}' which is not in @capabilities budget", fn_node, "add '{eff}' to @capabilities")
+                        diag_error_at("CapabilityBudgetExceeded", CAPABILITY_BUDGET, "function '{fn_name}' uses effect '{eff}' which is not in @capabilities budget", fn_node, "add '{eff}' to @capabilities")
                     }
                     ei = ei + 1
                 }
@@ -975,7 +988,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
         let trait_name = node_trait_name(im)
         let impl_type = node_name(im)
         if is_trait_name(trait_name) == 0 {
-            diag_error_at("TraitContract", "E0904", "trait '{trait_name}' is not defined", im, "check the trait name or define 'trait {trait_name} \{ ... }'")
+            diag_error_at("TraitContract", TRAIT_CONTRACT_904, "trait '{trait_name}' is not defined", im, "check the trait name or define 'trait {trait_name} \{ ... }'")
             ii = ii + 1
             continue
         }
@@ -1001,7 +1014,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
                                 impl_pcount = sublist_length(impl_params_sl)
                             }
                             if trait_pcount != impl_pcount {
-                                diag_error_at("TraitContract", "E0901", "method '{expected_method}' in impl {trait_name} for {impl_type} has {impl_pcount} params, expected {trait_pcount}", impl_m, "trait requires {trait_pcount} parameters (including self)")
+                                diag_error_at("TraitContract", TRAIT_CONTRACT_901, "method '{expected_method}' in impl {trait_name} for {impl_type} has {impl_pcount} params, expected {trait_pcount}", impl_m, "trait requires {trait_pcount} parameters (including self)")
                             } else {
                                 // Check param types
                                 let tp_start = tmsig.params_start
@@ -1014,7 +1027,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
                                         let impl_ptype = if raw_impl_ptype == "Self" { impl_type } else { raw_impl_ptype }
                                         let expected_type = subst_trait_type(trait_ptype, impl_type, si, im)
                                         if impl_ptype != expected_type {
-                                            diag_error_at("TraitContract", "E0902", "method '{expected_method}' param has type '{impl_ptype}', expected '{expected_type}'", impl_p, "change type to '{expected_type}' to match trait {trait_name}")
+                                            diag_error_at("TraitContract", TRAIT_CONTRACT_902, "method '{expected_method}' param has type '{impl_ptype}', expected '{expected_type}'", impl_p, "change type to '{expected_type}' to match trait {trait_name}")
                                         }
                                     }
                                     pi = pi + 1
@@ -1026,7 +1039,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
                                     let impl_ret = if raw_impl_ret == "Self" { impl_type } else { raw_impl_ret }
                                     let expected_ret = subst_trait_type(trait_ret, impl_type, si, im)
                                     if impl_ret != expected_ret {
-                                        diag_error_at("TraitContract", "E0903", "method '{expected_method}' returns '{impl_ret}', expected '{expected_ret}'", impl_m, "change return type to '{expected_ret}' to match trait {trait_name}")
+                                        diag_error_at("TraitContract", TRAIT_CONTRACT_903, "method '{expected_method}' returns '{impl_ret}', expected '{expected_ret}'", impl_m, "change return type to '{expected_ret}' to match trait {trait_name}")
                                     }
                                 }
                             }
@@ -1036,7 +1049,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
                     }
                 }
                 if found == 0 {
-                    diag_error_at("TraitContract", "E0900", "impl {trait_name} for {impl_type} is missing method '{expected_method}'", im, "add 'fn {expected_method}(...)' to the impl block")
+                    diag_error_at("TraitContract", TRAIT_CONTRACT_900, "impl {trait_name} for {impl_type} is missing method '{expected_method}'", im, "add 'fn {expected_method}(...)' to the impl block")
                 }
             }
             si = si + 1
@@ -1060,7 +1073,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
                     }
                 }
                 if found_assoc == 0 {
-                    diag_error_at("TraitContract", "E0905", "impl {trait_name} for {impl_type} is missing associated type '{expected_assoc}'", im, "add 'type {expected_assoc} = ...' to the impl block")
+                    diag_error_at("TraitContract", TRAIT_CONTRACT_905, "impl {trait_name} for {impl_type} is missing associated type '{expected_assoc}'", im, "add 'type {expected_assoc} = ...' to the impl block")
                 }
             }
             ati = ati + 1
@@ -1071,7 +1084,7 @@ fn validate_trait_impls(program: Int) ! TypeCheck.Register, Diag.Report {
             while ci < sublist_length(impls_sl) {
                 let other = sublist_get(impls_sl, ci)
                 if node_trait_name(other) == conflict_trait && node_name(other) == impl_type {
-                    diag_error_at("TraitContract", "E0906", "type '{impl_type}' cannot implement both Closeable and BlockHandler (ambiguous with-block semantics)", im, "remove one of the impl blocks")
+                    diag_error_at("TraitContract", TRAIT_CONTRACT_906, "type '{impl_type}' cannot implement both Closeable and BlockHandler (ambiguous with-block semantics)", im, "remove one of the impl blocks")
                     break
                 }
                 ci = ci + 1
@@ -1538,9 +1551,9 @@ fn nr_check_selective_access(name: Str, node: Int) -> Int ! Diag.Report {
     if is_filtered_for_module(name, source_mod, nr_current_module) != 0 {
         let display_mod = tc_qualifier_for_module(source_mod)
         if node == -1 {
-            diag_error_no_loc("ImportNotSelected", "E1006", "'{name}' is not in scope — add it to the import list or use qualified access '{display_mod}.{name}'", "add '{name}' to your selective import")
+            diag_error_no_loc("ImportNotSelected", IMPORT_NOT_SELECTED, "'{name}' is not in scope — add it to the import list or use qualified access '{display_mod}.{name}'", "add '{name}' to your selective import")
         } else {
-            diag_error_at("ImportNotSelected", "E1006", "'{name}' is not in scope — add it to the import list or use qualified access '{display_mod}.{name}'", node, "add '{name}' to your selective import")
+            diag_error_at("ImportNotSelected", IMPORT_NOT_SELECTED, "'{name}' is not in scope — add it to the import list or use qualified access '{display_mod}.{name}'", node, "add '{name}' to your selective import")
         }
         return 1
     }
@@ -1560,7 +1573,7 @@ fn nr_check_ambiguity(name: Str, mod_name: Str, local_names: Map[Str, Int]) ! Di
     match nr_name_source_module.get(name) {
         Some(existing_mod) => {
             if existing_mod != mod_name && existing_mod != "__main__" {
-                diag_error_no_loc("AmbiguousImport", "E1005", "name '{name}' is ambiguous — imported from both '{existing_mod}' and '{mod_name}'", "use selective imports to disambiguate, e.g. import {existing_mod}.\{name}")
+                diag_error_no_loc("AmbiguousImport", AMBIGUOUS_IMPORT, "name '{name}' is ambiguous — imported from both '{existing_mod}' and '{mod_name}'", "use selective imports to disambiguate, e.g. import {existing_mod}.\{name}")
             }
         }
         None => nr_name_source_module.insert(name, mod_name)
@@ -1622,9 +1635,9 @@ fn nr_pop_scope() ! Diag.Report {
                 let nd = nr_scope_nodes.get(i).unwrap()
                 if nd != -1 {
                     if nr_scope_writes.get(i).unwrap() > 1 {
-                        diag_warn_at("SetButNotRead", "W0601", "variable '{vname}' is assigned a value that is never read", nd, "remove the unused assignment, or prefix with '_' to suppress")
+                        diag_warn_at("SetButNotRead", SET_BUT_NOT_READ, "variable '{vname}' is assigned a value that is never read", nd, "remove the unused assignment, or prefix with '_' to suppress")
                     } else {
-                        diag_warn_at("UnusedVariable", "W0600", "variable '{vname}' is never read", nd, "prefix with '_' to suppress this warning")
+                        diag_warn_at("UnusedVariable", UNUSED_VARIABLE, "variable '{vname}' is never read", nd, "prefix with '_' to suppress this warning")
                     }
                 }
             }
@@ -1663,7 +1676,7 @@ fn nr_check_shadow(name: Str, node: Int) ! Diag.Report {
     let mut i = 0
     while i < frame_start {
         if nr_scope_names.get(i).unwrap() == name {
-            diag_warn_at("ShadowedVariable", "W0603", "variable '{name}' shadows a variable from an outer scope", node, "rename the variable or prefix with '_' to suppress")
+            diag_warn_at("ShadowedVariable", SHADOWED_VARIABLE, "variable '{name}' shadows a variable from an outer scope", node, "rename the variable or prefix with '_' to suppress")
             return
         }
         i = i + 1
@@ -2518,7 +2531,7 @@ fn nr_check_type_ref(name: Str) ! TypeCheck.Resolve, Diag.Report {
         if nr_check_selective_access(name, -1) != 0 { return }
         if is_private_access(name) != 0 {
             tc_errors.push("cannot access private type '{name}'")
-            diag_error_no_loc("PrivateItemAccess", "E1003", "cannot access private type '{name}' from another module", "mark the type as 'pub' in its module")
+            diag_error_no_loc("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private type '{name}' from another module", "mark the type as 'pub' in its module")
             return
         }
         tc_mark_symbol_used(name)
@@ -2528,14 +2541,14 @@ fn nr_check_type_ref(name: Str) ! TypeCheck.Resolve, Diag.Report {
         if nr_check_selective_access(name, -1) != 0 { return }
         if is_private_access(name) != 0 {
             tc_errors.push("cannot access private trait '{name}'")
-            diag_error_no_loc("PrivateItemAccess", "E1003", "cannot access private trait '{name}' from another module", "mark the trait as 'pub' in its module")
+            diag_error_no_loc("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private trait '{name}' from another module", "mark the trait as 'pub' in its module")
             return
         }
         tc_mark_symbol_used(name)
         return
     }
     tc_errors.push("unknown type '{name}'")
-    diag_error_no_loc("UnknownType", "E0507", "unknown type '{name}'", "")
+    diag_error_no_loc("UnknownType", UNKNOWN_TYPE, "unknown type '{name}'", "")
 }
 
 fn is_bytes_growth_method(name: Str) -> Int {
@@ -2560,7 +2573,7 @@ fn nogrow_scan(node: Int, recv: Str, with_ptr_site: Int) ! Diag.Report {
         if mc_obj != -1 && node_kind(mc_obj) == NodeKind.Ident && node_name(mc_obj) == recv {
             let m = node_method(node)
             if is_bytes_growth_method(m) != 0 {
-                diag_error_at("BytesGrowInWithPtr", "E0814", "cannot grow Bytes inside with_ptr closure — '{m}' is growth-effecting", node, "move the growth call outside the with_ptr closure")
+                diag_error_at("BytesGrowInWithPtr", BYTES_GROW_IN_WITH_PTR, "cannot grow Bytes inside with_ptr closure — '{m}' is growth-effecting", node, "move the growth call outside the with_ptr closure")
             }
         }
         let args_sl = node_args(node)
@@ -2569,7 +2582,7 @@ fn nogrow_scan(node: Int, recv: Str, with_ptr_site: Int) ! Diag.Report {
             while i < sublist_length(args_sl) {
                 let a = sublist_get(args_sl, i)
                 if node_kind(a) == NodeKind.Ident && node_name(a) == recv {
-                    diag_error_at("PinnedBytesEscape", "E0815", "pinned Bytes '{recv}' cannot escape with_ptr closure as argument", a, "pass the Ptr[U8] 'p' or an integer slice instead")
+                    diag_error_at("PinnedBytesEscape", PINNED_BYTES_ESCAPE, "pinned Bytes '{recv}' cannot escape with_ptr closure as argument", a, "pass the Ptr[U8] 'p' or an integer slice instead")
                 } else {
                     nogrow_scan(a, recv, with_ptr_site)
                 }
@@ -2589,7 +2602,7 @@ fn nogrow_scan(node: Int, recv: Str, with_ptr_site: Int) ! Diag.Report {
             while i < sublist_length(args_sl) {
                 let a = sublist_get(args_sl, i)
                 if node_kind(a) == NodeKind.Ident && node_name(a) == recv {
-                    diag_error_at("PinnedBytesEscape", "E0815", "pinned Bytes '{recv}' cannot escape with_ptr closure as argument", a, "pass the Ptr[U8] 'p' or an integer slice instead")
+                    diag_error_at("PinnedBytesEscape", PINNED_BYTES_ESCAPE, "pinned Bytes '{recv}' cannot escape with_ptr closure as argument", a, "pass the Ptr[U8] 'p' or an integer slice instead")
                 } else {
                     nogrow_scan(a, recv, with_ptr_site)
                 }
@@ -2803,7 +2816,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
             if nr_check_selective_access(name, node) != 0 { return }
             if is_private_access(name) != 0 {
                 tc_errors.push("cannot access private item '{name}'")
-                diag_error_at("PrivateItemAccess", "E1003", "cannot access private item '{name}' from another module", node, "mark the item as 'pub' in its module")
+                diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private item '{name}' from another module", node, "mark the item as 'pub' in its module")
                 return
             }
             tc_mark_symbol_used(name)
@@ -2815,7 +2828,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
             if nr_check_selective_access(name, node) != 0 { return }
             if is_private_access(name) != 0 {
                 tc_errors.push("cannot access private variant '{name}'")
-                diag_error_at("PrivateItemAccess", "E1003", "cannot access private variant '{name}' from another module", node, "mark the enum as 'pub' in its module")
+                diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private variant '{name}' from another module", node, "mark the enum as 'pub' in its module")
                 return
             }
             tc_mark_symbol_used(name)
@@ -2826,7 +2839,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
             if nr_check_selective_access(name, node) != 0 { return }
             if is_private_access(name) != 0 {
                 tc_errors.push("cannot access private type '{name}'")
-                diag_error_at("PrivateItemAccess", "E1003", "cannot access private type '{name}' from another module", node, "mark the type as 'pub' in its module")
+                diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private type '{name}' from another module", node, "mark the type as 'pub' in its module")
                 return
             }
             tc_mark_symbol_used(name)
@@ -2836,7 +2849,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
             if nr_check_selective_access(name, node) != 0 { return }
             if is_private_access(name) != 0 {
                 tc_errors.push("cannot access private trait '{name}'")
-                diag_error_at("PrivateItemAccess", "E1003", "cannot access private trait '{name}' from another module", node, "mark the trait as 'pub' in its module")
+                diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private trait '{name}' from another module", node, "mark the trait as 'pub' in its module")
                 return
             }
             tc_mark_symbol_used(name)
@@ -2844,7 +2857,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
         }
         if is_import_module_name(name) != 0 { return }
         tc_errors.push("undefined variable '{name}'")
-        diag_error_at("UndefinedVariable", "E0506", "undefined variable '{name}'", node, "")
+        diag_error_at("UndefinedVariable", UNDEFINED_VARIABLE, "undefined variable '{name}'", node, "")
         return
     }
 
@@ -2883,13 +2896,13 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
                 if nr_check_selective_access(fn_name, node) == 0 {
                     if nr_is_defined(fn_name) != 0 && is_private_access(fn_name) != 0 {
                         tc_errors.push("cannot access private function '{fn_name}'")
-                        diag_error_at("PrivateItemAccess", "E1003", "cannot access private function '{fn_name}' from another module", node, "mark the function as 'pub' in its module")
+                        diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private function '{fn_name}' from another module", node, "mark the function as 'pub' in its module")
                     } else if is_variant_name(fn_name) != 0 && is_private_access(fn_name) != 0 {
                         tc_errors.push("cannot access private variant '{fn_name}'")
-                        diag_error_at("PrivateItemAccess", "E1003", "cannot access private variant '{fn_name}' from another module", node, "mark the enum as 'pub' in its module")
+                        diag_error_at("PrivateItemAccess", PRIVATE_ITEM_ACCESS, "cannot access private variant '{fn_name}' from another module", node, "mark the enum as 'pub' in its module")
                     } else if nr_is_defined(fn_name) == 0 && is_builtin_fn(fn_name) == 0 && is_variant_name(fn_name) == 0 && is_known_type(fn_name) == 0 && is_trait_name(fn_name) == 0 {
                         tc_errors.push("undefined function '{fn_name}'")
-                        diag_error_at("UndefinedFunction", "E0504", "undefined function '{fn_name}'", node, "")
+                        diag_error_at("UndefinedFunction", UNDEFINED_FUNCTION, "undefined function '{fn_name}'", node, "")
                     } else {
                         tc_mark_symbol_used(fn_name)
                     }
@@ -2933,7 +2946,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
                             tc_mark_symbol_used(mid_field)
                             tc_mark_symbol_used(outer_field)
                             let dotted_mod = tc_get_dotted_module_path(inner_name)
-                            diag_error_at("ModuleQualifiedType", "E1007", "cannot access type member '{mid_field}.{outer_field}' via module qualifier — add '{mid_field}' to your import: 'import {dotted_mod}.\{{mid_field}\}' then use '{mid_field}.{outer_field}'", node, "enum variants and type members use type qualifiers, not module qualifiers")
+                            diag_error_at("ModuleQualifiedType", MODULE_QUALIFIED_TYPE, "cannot access type member '{mid_field}.{outer_field}' via module qualifier — add '{mid_field}' to your import: 'import {dotted_mod}.\{{mid_field}\}' then use '{mid_field}.{outer_field}'", node, "enum variants and type members use type qualifiers, not module qualifiers")
                             return
                         }
                     }
@@ -2959,7 +2972,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
                     }
                 }
                 if is_ue_call == 0 {
-                    diag_warn_at("UnknownMethod", "W0501", "unknown method '{method_name}' — may fail at compile time", node, "")
+                    diag_warn_at("UnknownMethod", UNKNOWN_METHOD, "unknown method '{method_name}' — may fail at compile time", node, "")
                 }
             }
         }
@@ -2978,7 +2991,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
         if method_name == "as_ptr" && nr_with_ptr_depth == 0 && obj_is_ident != 0 {
             let recv_t = infer_type(obj)
             if type_kind(recv_t) == TK_BYTES {
-                diag_error_at("BytesPtrCastForbidden", "E0817", "cannot take a raw Ptr[U8] from Bytes outside a with_ptr closure — Bytes is GC-managed and may be relocated", node, "use Bytes.with_ptr(fn(p) \{ ... }) to pin the buffer for the FFI call")
+                diag_error_at("BytesPtrCastForbidden", BYTES_PTR_CAST_FORBIDDEN, "cannot take a raw Ptr[U8] from Bytes outside a with_ptr closure — Bytes is GC-managed and may be relocated", node, "use Bytes.with_ptr(fn(p) \{ ... }) to pin the buffer for the FFI call")
             }
         }
         if is_with_ptr_call != 0 {
@@ -3018,7 +3031,7 @@ fn nr_check_node(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
                             tc_mark_symbol_used(mid_field)
                             tc_mark_symbol_used(outer_field)
                             let dotted_mod = tc_get_dotted_module_path(inner_name)
-                            diag_error_at("ModuleQualifiedType", "E1007", "cannot access type member '{mid_field}.{outer_field}' via module qualifier — add '{mid_field}' to your import: 'import {dotted_mod}.\{{mid_field}\}' then use '{mid_field}.{outer_field}'", node, "enum variants and type members use type qualifiers, not module qualifiers")
+                            diag_error_at("ModuleQualifiedType", MODULE_QUALIFIED_TYPE, "cannot access type member '{mid_field}.{outer_field}' via module qualifier — add '{mid_field}' to your import: 'import {dotted_mod}.\{{mid_field}\}' then use '{mid_field}.{outer_field}'", node, "enum variants and type members use type qualifiers, not module qualifiers")
                             return
                         }
                     }
@@ -3445,7 +3458,7 @@ fn type_bit_width(tid: Int) -> Int {
 
 fn warn_bitwise_vs_comparison(child: Int, parent: Int, op: Str) ! TypeCheck.Report, Diag.Report {
     if child != -1 && node_kind(child) == NodeKind.BinOp && is_comparison_op(node_op(child)) {
-        diag_warn_at("BitwisePrecedence", "W0700", "bitwise '{op}' applied to comparison result; use parentheses to clarify", parent, "wrap the comparison or the bitwise op in parentheses")
+        diag_warn_at("BitwisePrecedence", BITWISE_PRECEDENCE, "bitwise '{op}' applied to comparison result; use parentheses to clarify", parent, "wrap the comparison or the bitwise op in parentheses")
     }
 }
 
@@ -3576,13 +3589,13 @@ fn infer_type(node: Int) -> Int ! TypeCheck.Resolve, TypeCheck.Report, Diag.Repo
                     let ret_kind = ty_pool.get(tc_current_fn_ret).unwrap().kind
                     if ret_kind != TK_RESULT && ret_kind != TK_UNKNOWN {
                         tc_errors.push("'?' on Result in function '{tc_current_fn_name}' which does not return Result")
-                        diag_error_at("QuestionMarkResultInNonResult", "E0508", "'?' on Result in function '{tc_current_fn_name}' which does not return Result", node, "change the return type to Result[T, E]")
+                        diag_error_at("QuestionMarkResultInNonResult", QM_RESULT_IN_NON_RESULT, "'?' on Result in function '{tc_current_fn_name}' which does not return Result", node, "change the return type to Result[T, E]")
                     } else if ret_kind == TK_RESULT {
                         let operand_err = ty_pool.get(operand).unwrap().inner2
                         let ret_err = ty_pool.get(tc_current_fn_ret).unwrap().inner2
                         if types_compatible(operand_err, ret_err) == 0 {
                             tc_errors.push("'?' error type mismatch in function '{tc_current_fn_name}'")
-                            diag_error_at("QuestionMarkErrorMismatch", "E0512", "'?' error type mismatch: operand error type does not match return error type in '{tc_current_fn_name}'", node, "ensure the error types are compatible")
+                            diag_error_at("QuestionMarkErrorMismatch", QM_ERROR_MISMATCH, "'?' error type mismatch: operand error type does not match return error type in '{tc_current_fn_name}'", node, "ensure the error types are compatible")
                         }
                     }
                 }
@@ -3593,14 +3606,14 @@ fn infer_type(node: Int) -> Int ! TypeCheck.Resolve, TypeCheck.Report, Diag.Repo
                     let ret_kind = ty_pool.get(tc_current_fn_ret).unwrap().kind
                     if ret_kind != TK_OPTION && ret_kind != TK_UNKNOWN {
                         tc_errors.push("'?' on Option in function '{tc_current_fn_name}' which does not return Option")
-                        diag_error_at("QuestionMarkOptionInNonOption", "E0509", "'?' on Option in function '{tc_current_fn_name}' which does not return Option", node, "change the return type to Option[T]")
+                        diag_error_at("QuestionMarkOptionInNonOption", QM_OPTION_IN_NON_OPTION, "'?' on Option in function '{tc_current_fn_name}' which does not return Option", node, "change the return type to Option[T]")
                     }
                 }
                 return ty_pool.get(operand).unwrap().inner1
             }
             if ok != TK_UNKNOWN {
                 tc_errors.push("'?' requires Result or Option value")
-                diag_error_at("QuestionMarkInvalidOperand", "E0502", "'?' requires a Result or Option value", node, "")
+                diag_error_at("QuestionMarkInvalidOperand", QM_INVALID_OPERAND, "'?' requires a Result or Option value", node, "")
             }
             return operand
         }
@@ -4092,7 +4105,7 @@ fn tc_check_body(node: Int) ! TypeCheck.Resolve, TypeCheck.Report, Diag.Report {
             while i < sublist_length(stmts_sl) {
                 let stmt = sublist_get(stmts_sl, i)
                 if _found_terminal != 0 {
-                    diag_warn_at("UnreachableCode", "W0700", "unreachable code after return/break/continue", stmt, "remove this code or move it before the control flow statement")
+                    diag_warn_at("UnreachableCode", UNREACHABLE_CODE, "unreachable code after return/break/continue", stmt, "remove this code or move it before the control flow statement")
                 }
                 tc_check_body(stmt)
                 let sk = node_kind(stmt)


### PR DESCRIPTION
## Summary

Bundled cleanup of two P4 chores from `br ready -t repo:blink`:

- **mzkqp4** — Replaced bare diagnostic-code string literals (`"E0502"`, `"W0812"`, …) at ~108 emit sites across 11 modules with named `pub const` symbols defined in `src/diagnostics.bl`. One constant per `(code, short-name)` pair.
- **nsf50n** — Extracted inline `List[Str]` membership scans into `pub fn list_contains_str` in `src/codegen_types.bl`, migrated all 3 named sites plus a duplicate `ident_in_list` in `escape.bl` (caught in `/simplify`), and inlined the `is_mut_captured` wrapper at its 5 callers.

No behavioral change — codegen output byte-identical, single regen cycle, full test suite green.

## Follow-up

Filed `8enkmg` for diagnostic code collisions made visible by the constants table (E0501, E0502, E0700, E0900–906, E1100, E1108 each map to multiple unrelated short-names).

## Test plan

- [x] `task regen` — Gen1 vs Gen2 byte-identical
- [x] `task ci` — 264/264 tests, 644/644 fmt goldens
- [x] Exit gate: `rg '"[EWI][0-9]{4}' src/ | grep -v diagnostics.bl` → only test-helper match (expected)
- [x] `bin/blink check .tmp/bad.bl` still emits `error[TypeError]` with same code